### PR TITLE
signature change to avoid value truncation

### DIFF
--- a/src/contrac.cpp
+++ b/src/contrac.cpp
@@ -54,7 +54,7 @@ bool Contrac::generateTracingKey()
     return (result == 1);
 }
 
-bool Contrac::generateDailyTracingKey(quint8 day_number)
+bool Contrac::generateDailyTracingKey(quint32 day_number)
 {
     int result = 1;
     unsigned char encode[sizeof(DTK_INFO_PREFIX) + sizeof(day_number)];

--- a/src/contrac.h
+++ b/src/contrac.h
@@ -52,7 +52,7 @@ public slots:
 
 private:
     bool generateTracingKey();
-    bool generateDailyTracingKey(quint8 day_number);
+    bool generateDailyTracingKey(quint32 day_number);
     bool generateRandomProximityIdentifier(quint8 time_interval_number);
 
     static quint32 epochToDayNumber(quint64 epoch);


### PR DESCRIPTION
m_day_number was incorrectly set as it was being downsized from quint32 to quint8