### PR TITLE
Support uploading keys to the submission server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,15 @@ More info: https://www.flypig.co.uk/contrac
 8.  Align with GApple API - DONE
 9.  Run as a service - DONE
 10. Service dbus interface - DONE
-11. Diagnosis key download - WORKING
-12. Diagnosis key upload
-13. Test against official apps
+11. Diagnosis key download - DONE
+12. Diagnosis key upload - DONE
+13. Test against official apps - PARTIAL
+14. Update to latest GApple protocol
+15. Risk config download
+16. Persistent settings
+17. User teleTAN input
+18. Test against official servers
+19. Scrub up the UI
 
 ## Contact Tracing Apps
 

--- a/contrac.pro
+++ b/contrac.pro
@@ -19,9 +19,22 @@ VERSION_BUILD = 1
 #Target version
 VERSION = $${VERSION_MAJOR}.$${VERSION_MINOR}-$${VERSION_BUILD}
 
+#protobuf build step
+PRE_TARGETDEPS += proto/submissionpayload.pb.cc
+protobuf.target = proto/submissionpayload.pb.cc
+protobuf.path = $$OUT_PWD
+protobuf.commands = \
+    mkdir -p $$OUT_PWD/proto; \
+    protoc --proto_path=$$PWD/src --cpp_out=$$OUT_PWD/proto $$PWD/src/submissionpayload.proto
+
+INCLUDEPATH += $$OUT_PWD/proto
+
+QMAKE_EXTRA_TARGETS += protobuf
+
 CONFIG += sailfishapp
 
 HEADERS += \
+    proto/submissionpayload.pb.h \
     src/dbusproxy.h \
     src/contactmodel.h \
     src/download.h \
@@ -32,9 +45,12 @@ HEADERS += \
     contracd/src/exposuresummary.h \
     contracd/src/exposureinformation.h \
     contracd/src/temporaryexposurekey.h \
-    contracd/src/exposureconfiguration.h
+    contracd/src/exposureconfiguration.h \
+    src/upload.h
 
-SOURCES += src/harbour-contrac.cpp \
+SOURCES += \
+    proto/submissionpayload.pb.cc \
+    src/harbour-contrac.cpp \
     src/dbusproxy.cpp \
     src/contactmodel.cpp \
     src/download.cpp \
@@ -47,9 +63,11 @@ SOURCES += src/harbour-contrac.cpp \
     contracd/src/exposuresummary.cpp \
     contracd/src/exposureinformation.cpp \
     contracd/src/temporaryexposurekey.cpp \
-    contracd/src/exposureconfiguration.cpp
+    contracd/src/exposureconfiguration.cpp \
+    src/upload.cpp
 
-DISTFILES += qml/harbour-contrac.qml \
+DISTFILES += \
+    qml/harbour-contrac.qml \
     qml/cover/CoverPage.qml \
     qml/pages/About.qml \
     qml/pages/Main.qml \
@@ -75,11 +93,13 @@ TRANSLATIONS += translations/harbour-contrac-zh_CN.ts
 PKGCONFIG += \
     openssl \
     libxml-2.0 \
-    libcurl
+    libcurl \
+    protobuf-lite \
 
 DEFINES += LINUX
 
 QT += dbus
 
 OTHER_FILES += \
+    src/submissionpayload.proto \
     icons/*.svg

--- a/contracd/contracd.pro
+++ b/contracd/contracd.pro
@@ -4,6 +4,9 @@ VERSION_MAJOR = 0
 VERSION_MINOR = 0
 VERSION_BUILD = 1
 
+#Target version
+VERSION = $${VERSION_MAJOR}.$${VERSION_MINOR}-$${VERSION_BUILD}
+
 #protobuf build step
 PRE_TARGETDEPS += proto/contrac.pb.cc
 protobuf.target = proto/contrac.pb.cc
@@ -15,9 +18,6 @@ protobuf.commands = \
 INCLUDEPATH += $$OUT_PWD/proto
 
 QMAKE_EXTRA_TARGETS += protobuf
-
-#Target version
-VERSION = $${VERSION_MAJOR}.$${VERSION_MINOR}-$${VERSION_BUILD}
 
 CONFIG += sailfishapp
 
@@ -73,7 +73,6 @@ SOURCES += \
     src/zipistreambuffer.cpp
 
 DISTFILES += \
-    src/contrac.proto \
     contracd.service \
     contracd.privileges \
 
@@ -85,6 +84,7 @@ PKGCONFIG += \
 QT += dbus
 
 OTHER_FILES += \
+    src/contrac.proto
 
 service.files = $${TARGET}.service
 service.path = /usr/lib/systemd/user/

--- a/contracd/src/dbusinterface.h
+++ b/contracd/src/dbusinterface.h
@@ -21,14 +21,15 @@ class DBusInterface : public QObject
     // Non-standard additions
     Q_PROPERTY(quint32 receivedCount READ receivedCount NOTIFY receivedCountChanged)
     Q_PROPERTY(quint32 sentCount READ sentCount NOTIFY sentCountChanged)
+    Q_PROPERTY(bool isBusy READ isBusy NOTIFY isBusyChanged)
 
 public:
     explicit DBusInterface(QObject *parent = nullptr);
     ~DBusInterface();
 
-    ExposureNotification::Status status() const;
-    bool isEnabled() const;
-    quint32 maxDiagnosisKeys() const;
+    Q_INVOKABLE ExposureNotification::Status status() const;
+    Q_INVOKABLE bool isEnabled() const;
+    Q_INVOKABLE quint32 maxDiagnosisKeys() const;
 
     Q_INVOKABLE void start();
     Q_INVOKABLE void stop();
@@ -42,6 +43,7 @@ public:
     // Non-standard additions
     Q_INVOKABLE quint32 receivedCount() const;
     Q_INVOKABLE quint32 sentCount() const;
+    Q_INVOKABLE bool isBusy() const;
 
 signals:
     void statusChanged();
@@ -50,6 +52,7 @@ signals:
     // Non-standard additions
     void receivedCountChanged();
     void sentCountChanged();
+    void isBusyChanged();
 
 public slots:
 
@@ -65,19 +68,6 @@ private:
     quint32 m_receivedCount;
 };
 
-typedef QList<TemporaryExposureKey> TemporaryExposureKeyList;
-
-QDBusArgument &operator<<(QDBusArgument &argument, const TemporaryExposureKeyList &temporaryExposureKeyList);
-QDBusArgument const &operator>>(const QDBusArgument &argument, TemporaryExposureKeyList &temporaryExposureKeyList);
-
-Q_DECLARE_METATYPE(TemporaryExposureKeyList)
-
-typedef QList<ExposureInformation> ExposureInformationList;
-
-QDBusArgument &operator<<(QDBusArgument &argument, const ExposureInformationList &exposureInformationList);
-QDBusArgument const &operator>>(const QDBusArgument &argument, ExposureInformationList &exposureInformationList);
-
-Q_DECLARE_METATYPE(ExposureInformationList)
 
 
 #endif // DBUSINTERFACE_H

--- a/contracd/src/exposureinformation.cpp
+++ b/contracd/src/exposureinformation.cpp
@@ -76,6 +76,30 @@ QDBusArgument const &operator>>(const QDBusArgument &argument, ExposureInformati
     return argument;
 }
 
+QDBusArgument &operator<<(QDBusArgument &argument, const QList<ExposureInformation> &exposureInformationList)
+{
+    argument.beginArray(qMetaTypeId<ExposureInformation>());
+    for (ExposureInformation const & exposureInformation : exposureInformationList) {
+        argument << exposureInformation;
+    }
+    argument.endArray();
+
+    return argument;
+}
+
+QDBusArgument const &operator>>(const QDBusArgument &argument, QList<ExposureInformation> &exposureInformationList)
+{
+    argument.beginArray();
+    while (!argument.atEnd()) {
+        ExposureInformation exposureInformation;
+        argument >> exposureInformation;
+        exposureInformationList.append(exposureInformation);
+    }
+    argument.endArray();
+
+    return argument;
+}
+
 quint64 ExposureInformation::dateMillisSinceEpoch() const
 {
     return m_dateMillisSinceEpoch;

--- a/contracd/src/exposureinformation.h
+++ b/contracd/src/exposureinformation.h
@@ -56,4 +56,9 @@ QDBusArgument const &operator>>(const QDBusArgument &argument, ExposureInformati
 
 Q_DECLARE_METATYPE(ExposureInformation)
 
+QDBusArgument &operator<<(QDBusArgument &argument, const QList<ExposureInformation> &exposureInformationList);
+QDBusArgument const &operator>>(const QDBusArgument &argument, QList<ExposureInformation> &exposureInformationList);
+
+Q_DECLARE_METATYPE(QList<ExposureInformation>)
+
 #endif // EXPOSUREINFORMATION_H

--- a/contracd/src/exposurenotification.h
+++ b/contracd/src/exposurenotification.h
@@ -25,6 +25,7 @@ class ExposureNotification : public QObject
     Q_ENUMS(Status)
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
     Q_PROPERTY(bool isEnabled READ isEnabled NOTIFY isEnabledChanged)
+    Q_PROPERTY(bool isBusy READ isBusy NOTIFY isBusyChanged)
     Q_PROPERTY(quint32 maxDiagnosisKeys READ maxDiagnosisKeys CONSTANT)
 public:
     explicit ExposureNotification(QObject *parent = nullptr);
@@ -43,6 +44,7 @@ public:
 
     Status status() const;
     bool isEnabled() const;
+    bool isBusy() const;
     quint32 maxDiagnosisKeys() const;
 
     Q_INVOKABLE void start();
@@ -57,6 +59,7 @@ public:
 signals:
     void statusChanged();
     void isEnabledChanged();
+    void isBusyChanged();
 
     void beaconSent();
     void beaconReceived();

--- a/contracd/src/temporaryexposurekey.cpp
+++ b/contracd/src/temporaryexposurekey.cpp
@@ -1,3 +1,5 @@
+#include <qdebug.h>
+
 #include "temporaryexposurekey.h"
 
 TemporaryExposureKey::TemporaryExposureKey(QObject *parent)
@@ -11,9 +13,10 @@ TemporaryExposureKey::TemporaryExposureKey(QObject *parent)
 
 TemporaryExposureKey::TemporaryExposureKey(TemporaryExposureKey const& temporaryExopsureKey)
     : QObject(temporaryExopsureKey.parent())
-    , m_rollingStartNumber(temporaryExopsureKey.rollingStartNumber())
-    , m_rollingPeriod(temporaryExopsureKey.rollingPeriod())
-    , m_transmissionRiskLevel(temporaryExopsureKey.transmissionRiskLevel())
+    , m_keyData(temporaryExopsureKey.m_keyData)
+    , m_rollingStartNumber(temporaryExopsureKey.m_rollingStartNumber)
+    , m_rollingPeriod(temporaryExopsureKey.m_rollingPeriod)
+    , m_transmissionRiskLevel(temporaryExopsureKey.m_transmissionRiskLevel)
 {
 }
 
@@ -45,6 +48,43 @@ QDBusArgument const &operator>>(const QDBusArgument &argument, TemporaryExposure
     argument >> valueInt8;
     temporaryExposureKey.setTransmissionRiskLevel(valueInt8);
     argument.endStructure();
+
+    return argument;
+}
+
+TemporaryExposureKey& TemporaryExposureKey::operator=( const TemporaryExposureKey &other)
+{
+    if (this != &other) {
+        setParent(other.parent());
+        m_keyData = other.m_keyData;
+        m_rollingStartNumber = other.m_rollingStartNumber;
+        m_rollingPeriod = other.m_rollingPeriod;
+        m_transmissionRiskLevel = other.m_transmissionRiskLevel;
+    }
+
+    return *this;
+}
+
+QDBusArgument &operator<<(QDBusArgument &argument, const QList<TemporaryExposureKey> &temporaryExposureKeyList)
+{
+    argument.beginArray(qMetaTypeId<TemporaryExposureKey>());
+    for (TemporaryExposureKey const & temporaryExposureKey : temporaryExposureKeyList) {
+        argument << temporaryExposureKey;
+    }
+    argument.endArray();
+
+    return argument;
+}
+
+QDBusArgument const &operator>>(const QDBusArgument &argument, QList<TemporaryExposureKey> &temporaryExposureKeyList)
+{
+    argument.beginArray();
+    while (!argument.atEnd()) {
+        TemporaryExposureKey temporaryExposureKey;
+        argument >> temporaryExposureKey;
+        temporaryExposureKeyList.append(temporaryExposureKey);
+    }
+    argument.endArray();
 
     return argument;
 }

--- a/contracd/src/temporaryexposurekey.h
+++ b/contracd/src/temporaryexposurekey.h
@@ -15,7 +15,9 @@ class TemporaryExposureKey : public QObject
 
 public:
     explicit TemporaryExposureKey(QObject *parent = nullptr);
-    explicit TemporaryExposureKey(TemporaryExposureKey const& temporaryExopsureKey);
+    TemporaryExposureKey(TemporaryExposureKey const& temporaryExopsureKey);
+    TemporaryExposureKey& operator=( const TemporaryExposureKey &other);
+
     enum RiskLevel
     {
         RiskLevelInvalid = 0,
@@ -58,5 +60,10 @@ QDBusArgument &operator<<(QDBusArgument &argument, const TemporaryExposureKey &t
 QDBusArgument const &operator>>(const QDBusArgument &argument, TemporaryExposureKey &temporaryExposureKey);
 
 Q_DECLARE_METATYPE(TemporaryExposureKey)
+
+QDBusArgument &operator<<(QDBusArgument &argument, const QList<TemporaryExposureKey> &temporaryExposureKeyList);
+QDBusArgument const &operator>>(const QDBusArgument &argument, QList<TemporaryExposureKey> &temporaryExposureKeyList);
+
+Q_DECLARE_METATYPE(QList<TemporaryExposureKey>)
 
 #endif // TEMPORARYEXPOSUREKEY_H

--- a/qml/pages/Main.qml
+++ b/qml/pages/Main.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
+import org.nemomobile.time 1.0
 import uk.co.flypig 1.0
 
 Page {
@@ -8,12 +9,31 @@ Page {
 
     allowedOrientations: Orientation.All
 
+    WallClock {
+        id: wallclock
+        updateFrequency: WallClock.Day
+    }
+
     ExposureConfiguration {
         id: config
     }
 
+    function moreThanADayAgo(latest) {
+        var result = true
+        if (!isNaN(latest)) {
+            var today = wallclock.time
+            today.setSeconds(0)
+            today.setMinutes(0)
+            today.setHours(0)
+            today.setMilliseconds(0)
+            result = ((today - latest) > (24 * 60 * 60 * 1000))
+        }
+        return result
+    }
+
     Download {
         id: download
+        property bool available: moreThanADayAgo(latest)
         onDownloadComplete: {
             var keyfiles = [ filename ]
 
@@ -21,6 +41,11 @@ Page {
 
             dbusproxy.provideDiagnosisKeys(keyfiles, config, token)
         }
+    }
+
+    Upload {
+        id: upload
+        property bool available: moreThanADayAgo(latest)
     }
 
     DBusProxy {
@@ -49,14 +74,36 @@ Page {
                 title: qsTrId("contrac-main_title")
             }
 
+            Label {
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                x: Theme.horizontalPageMargin
+                //% "Using the Google/Apple API"
+                text: qsTrId("contrac-main_using_google_apple_api")
+                color: Theme.highlightColor
+            }
+
+            Label {
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                x: Theme.horizontalPageMargin
+                //% "Using the Corona Warn App servers"
+                text: qsTrId("contrac-main_using_corona_warn_app_servers")
+                color: Theme.highlightColor
+            }
+
+            SectionHeader {
+                //% "Contact beacons"
+                text: qsTrId("contrac-main_contact_beacons")
+            }
+
             TextSwitch {
                 //% "Scan and send active"
                 text: qsTrId("contrac-main_scan")
                 width: parent.width - 2 * Theme.horizontalPageMargin
                 checked: dbusproxy.isEnabled
+                busy: dbusproxy.isBusy
                 automaticCheck: false
                 onClicked: {
-                    if (checked) {
+                    if (!checked) {
                         console.log("Clicked to start")
                         dbusproxy.start();
                     }
@@ -83,6 +130,41 @@ Page {
                 color: Theme.highlightColor
             }
 
+            SectionHeader {
+                //% "Diagnosis key uploads"
+                text: qsTrId("contrac-main_diagnosis_key_uploadss")
+            }
+
+            Label {
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                x: Theme.horizontalPageMargin
+                text: "Latest upload: " + Qt.formatDate(upload.latest, "d MMM yyyy")
+                color: Theme.highlightColor
+            }
+
+            ProgressBar {
+                id: uploadProgress
+                width: parent.width
+                maximumValue: 100
+                value: upload.available ? upload.progress * 100.0 : 100.0
+                label: (upload.status == Upload.StatusError) ? "Error" : "Upload progress"
+            }
+
+            Button {
+                anchors.horizontalCenter: parent.horizontalCenter
+                enabled: !upload.uploading && (dbusproxy.sentCount > 0) && upload.available
+                text: upload.uploading ? "Uploading" : "Upload"
+                onClicked: {
+                    console.log("Uploading")
+                    upload.upload("R3ZNUEV9JA")
+                }
+            }
+
+            SectionHeader {
+                //% "Diagnosis key downloads"
+                text: qsTrId("contrac-main_diagnosis_key_downloads")
+            }
+
             Label {
                 width: parent.width - 2 * Theme.horizontalPageMargin
                 x: Theme.horizontalPageMargin
@@ -90,9 +172,17 @@ Page {
                 color: Theme.highlightColor
             }
 
+            ProgressBar {
+                id: downloadProgress
+                width: parent.width
+                maximumValue: 100
+                value: download.available ? download.progress * 100.0 : 100.0
+                label: "Download progress"
+            }
+
             Button {
                 anchors.horizontalCenter: parent.horizontalCenter
-                enabled: !download.downloading
+                enabled: !download.downloading && download.available
                 text: download.downloading ? "Downloading" : "Download"
                 onClicked: download.downloadLatest()
             }

--- a/rpm/harbour-contrac.spec
+++ b/rpm/harbour-contrac.spec
@@ -19,6 +19,7 @@ Source100:  harbour-contrac.yaml
 Requires:   sailfishsilica-qt5 >= 0.10.9
 Requires:   openssl
 Requires:   protobuf-lite
+Requires:   nemo-qml-plugin-time-qt5
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)

--- a/rpm/harbour-contrac.yaml
+++ b/rpm/harbour-contrac.yaml
@@ -39,6 +39,7 @@ Requires:
   - sailfishsilica-qt5 >= 0.10.9 
   - openssl
   - protobuf-lite
+  - nemo-qml-plugin-time-qt5
 
 # All installed files
 Files:

--- a/src/dbusproxy.h
+++ b/src/dbusproxy.h
@@ -25,6 +25,7 @@ class DBusProxy : public QObject
     // Non-standard additions
     Q_PROPERTY(quint32 receivedCount READ receivedCount NOTIFY receivedCountChanged)
     Q_PROPERTY(quint32 sentCount READ sentCount NOTIFY sentCountChanged)
+    Q_PROPERTY(bool isBusy READ isBusy NOTIFY isBusyChanged)
 public:
     explicit DBusProxy(QObject *parent = nullptr);
     ~DBusProxy();
@@ -46,7 +47,7 @@ public:
 
     Q_INVOKABLE void start();
     Q_INVOKABLE void stop();
-    Q_INVOKABLE QList<TemporaryExposureKey> *getTemporaryExposureKeyHistory();
+    Q_INVOKABLE QList<TemporaryExposureKey> getTemporaryExposureKeyHistory();
     Q_INVOKABLE void provideDiagnosisKeys(QStringList const &keyFiles, ExposureConfiguration const &configuration, QString token);
     Q_INVOKABLE ExposureSummary *getExposureSummary(QString const &token) const;
     Q_INVOKABLE QList<ExposureInformation> *getExposureInformation(QString const &token) const;
@@ -55,6 +56,7 @@ public:
     // Non-standard additions
     quint32 receivedCount() const;
     quint32 sentCount() const;
+    bool isBusy() const;
 
 signals:
     void statusChanged();
@@ -63,6 +65,7 @@ signals:
     // Non-standard additions
     void receivedCountChanged();
     void sentCountChanged();
+    void isBusyChanged();
 
 public slots:
 
@@ -73,20 +76,5 @@ private:
 };
 
 Q_DECLARE_METATYPE(DBusProxy::Status)
-
-typedef QList<TemporaryExposureKey> TemporaryExposureKeyList;
-
-QDBusArgument &operator<<(QDBusArgument &argument, const TemporaryExposureKeyList &temporaryExposureKeyList);
-QDBusArgument const &operator>>(const QDBusArgument &argument, TemporaryExposureKeyList &temporaryExposureKeyList);
-
-Q_DECLARE_METATYPE(TemporaryExposureKeyList)
-
-typedef QList<ExposureInformation> ExposureInformationList;
-
-QDBusArgument &operator<<(QDBusArgument &argument, const ExposureInformationList &exposureInformationList);
-QDBusArgument const &operator>>(const QDBusArgument &argument, ExposureInformationList &exposureInformationList);
-
-Q_DECLARE_METATYPE(ExposureInformationList)
-
 
 #endif // DBUSPROXY_H

--- a/src/download.h
+++ b/src/download.h
@@ -12,6 +12,8 @@ class Download : public QObject
     Q_OBJECT
     Q_PROPERTY(QDate latest READ latest NOTIFY latestChanged)
     Q_PROPERTY(bool downloading READ downloading NOTIFY downloadingChanged)
+    Q_PROPERTY(float progress READ progress NOTIFY progressChanged)
+
 public:
     explicit Download(QObject *parent = nullptr);
 
@@ -19,11 +21,13 @@ public:
 
     QDate latest() const;
     bool downloading() const;
+    float progress() const;
 
 signals:
     void latestChanged();
     void downloadingChanged();
     void downloadComplete(QString const &filename);
+    void progressChanged();
 
 public slots:
 
@@ -41,6 +45,8 @@ private:
     QMap<QDate, QStringList> m_fileQueue;
     QDate m_latest;
     bool m_downloading;
+    qint64 m_filesReceived;
+    qint64 m_filesTotal;
 };
 
 #endif // DOWNLOAD_H

--- a/src/harbour-contrac.cpp
+++ b/src/harbour-contrac.cpp
@@ -11,6 +11,7 @@
 
 #include "dbusproxy.h"
 #include "download.h"
+#include "upload.h"
 
 #include <sailfishapp.h>
 
@@ -36,6 +37,7 @@ int main(int argc, char *argv[])
     qmlRegisterType<ExposureInformation>("uk.co.flypig", 1, 0, "ExposureInformation");
     qmlRegisterType<ExposureConfiguration>("uk.co.flypig", 1, 0, "ExposureConfiguration");
     qmlRegisterType<Download>("uk.co.flypig", 1, 0, "Download");
+    qmlRegisterType<Upload>("uk.co.flypig", 1, 0, "Upload");
 
     QQuickView *view = SailfishApp::createView();
     view->setSource(SailfishApp::pathTo("qml/harbour-contrac.qml"));

--- a/src/submissionpayload.proto
+++ b/src/submissionpayload.proto
@@ -1,0 +1,27 @@
+// For uploading diagnosis keys
+
+syntax = "proto2";
+
+package diagnosis;
+
+option optimize_for = LITE_RUNTIME;
+
+message SubmissionPayload {
+  repeated TemporaryExposureKey keys = 1;
+}
+
+message TemporaryExposureKey {
+  // Key of infected user
+  optional bytes key_data = 1;
+
+  // Varying risks associated with exposure depending on type of verification
+  optional int32 transmission_risk_level = 2;
+
+  // The interval number since epoch for which a key starts
+  optional int32 rolling_start_interval_number = 3;
+
+  // Increments of 10 minutes describing how long a key is valid
+  optional int32 rolling_period = 4
+      [default = 144];  // defaults to 24 hours
+}
+

--- a/src/upload.cpp
+++ b/src/upload.cpp
@@ -1,0 +1,331 @@
+#include <iostream>
+#include <fstream>
+#include <qjsonobject.h>
+#include <qjsondocument.h>
+#include <qdebug.h>
+
+#include "proto/submissionpayload.pb.h"
+#include <openssl/evp.h>
+#include "upload.h"
+
+#define UPLOAD_SERVER_ADDRESS "127.0.0.1:8000"
+#define VERIFICATION_SERVER_ADDRESS "127.0.0.1:8004"
+
+Upload::Upload(QObject *parent) : QObject(parent)
+  , m_manager(new QNetworkAccessManager(this))
+  , m_reply(nullptr)
+  , m_latest()
+  , m_bytesSent(0)
+  , m_bytesTotal(0)
+  , m_status(StatusIdle)
+{
+}
+
+void Upload::upload(QString const &teleTAN)
+{
+    if (((m_status == StatusIdle) || (m_status == StatusError)) && (m_reply == nullptr)) {
+        bool valid = validateTeleTAN(teleTAN);
+        if (valid) {
+            setStatus(StatusSubmitTeleTAN);
+            submitTeleTAN(teleTAN);
+        }
+        else {
+            qDebug() << "Invalid teleTAN";
+            setStatus(StatusError);
+        }
+    }
+    else {
+        // Do nothing until the existing upload completes
+        qDebug() << "Upload already in progress";
+    }
+}
+
+void Upload::submitTeleTAN(QString const &teleTAN)
+{
+    if ((m_status == StatusSubmitTeleTAN) && (m_reply == nullptr)) {
+        QNetworkRequest request;
+
+        request.setUrl(QUrl("http://" VERIFICATION_SERVER_ADDRESS "/version/v1/registrationToken"));
+        request.setRawHeader("accept", "*/*");
+        request.setRawHeader("Content-Type", "application/json");
+        request.setRawHeader("cwa-fake", "0");
+
+        QJsonObject body;
+        body.insert("keyType", "TELETAN");
+        body.insert("key", teleTAN);
+        QJsonDocument doc(body);
+        QByteArray data = doc.toJson();
+        m_reply = m_manager->post(request, data);
+
+        connect(m_reply, &QNetworkReply::finished, this, &Upload::onTeleTANFinished);
+    }
+    else {
+        qDebug() << "Incorrect state attempting to submit teleTAN";
+        setStatus(StatusError);
+    }
+}
+
+void Upload::onTeleTANFinished()
+{
+    QNetworkReply *reply = m_reply;
+    m_reply = nullptr;
+
+    if (reply->error() == QNetworkReply::NoError) {
+        QByteArray data = reply->readAll();
+
+        QJsonParseError error;
+        QJsonDocument doc = QJsonDocument::fromJson(data, &error);
+        if (doc.isNull()) {
+            qDebug() << "JSON error: " << error.errorString();
+            setStatus(StatusError);
+        }
+        else {
+            QString regToken = doc.object().value("registrationToken").toString();
+            if (regToken.isEmpty()) {
+                qDebug() << "Invalid registration token";
+                setStatus(StatusError);
+            }
+            else {
+                setStatus(StatusSubmitRegToken);
+                submitRegToken(regToken);
+            }
+        }
+    }
+    else {
+        qDebug() << "Network error while submitting teleTAN: " << reply->errorString();
+        setStatus(StatusError);
+    }
+    reply->deleteLater();
+}
+
+void Upload::submitRegToken(QString const &regToken)
+{
+    if ((m_status == StatusSubmitRegToken) && (m_reply == nullptr)) {
+        QNetworkRequest request;
+
+        request.setUrl(QUrl("http://" VERIFICATION_SERVER_ADDRESS "/version/v1/tan"));
+        request.setRawHeader("accept", "*/*");
+        request.setRawHeader("Content-Type", "application/json");
+        request.setRawHeader("cwa-fake", "0");
+
+        QJsonObject body;
+        body.insert("registrationToken", regToken);
+        QJsonDocument doc(body);
+        QByteArray data = doc.toJson();
+        m_reply = m_manager->post(request, data);
+
+        connect(m_reply, &QNetworkReply::finished, this, &Upload::onRegTokenFinished);
+    }
+    else {
+        qDebug() << "Incorrect state attempting to submit registration token";
+        setStatus(StatusError);
+    }
+}
+
+void Upload::onRegTokenFinished()
+{
+    QNetworkReply *reply = m_reply;
+    m_reply = nullptr;
+
+    if (reply->error() == QNetworkReply::NoError) {
+        QByteArray data = reply->readAll();
+
+        QJsonParseError error;
+        QJsonDocument doc = QJsonDocument::fromJson(data, &error);
+        if (doc.isNull()) {
+            qDebug() << "JSON error: " << error.errorString();
+            setStatus(StatusError);
+        }
+        else {
+            QString tan = doc.object().value("tan").toString();
+            if (tan.isEmpty()) {
+                qDebug() << "Invalid TAN";
+                setStatus(StatusError);
+            }
+            else {
+                setStatus(SubmitDiagnosisKeys);
+                submitDiagnosisKeys(tan);
+            }
+        }
+    }
+    else {
+        qDebug() << "Network error while submitting registration token: " << reply->errorString();
+        setStatus(StatusError);
+    }
+    reply->deleteLater();
+}
+
+void Upload::submitDiagnosisKeys(QString const &tan)
+{
+    if ((m_status == SubmitDiagnosisKeys) && (m_reply == nullptr)) {
+        diagnosis::SubmissionPayload payload;
+        QNetworkRequest request;
+        DBusProxy proxy(this);
+
+        // Get the latest keys for upload
+        QList<TemporaryExposureKey> exposureKeys = proxy.getTemporaryExposureKeyHistory();
+
+        qDebug() << "Generating submission payload";
+        qDebug() << "Keys to output: " << exposureKeys.length();
+
+        // Convert the keys into protobuffer format
+        for (TemporaryExposureKey const &key : exposureKeys) {
+            diagnosis::TemporaryExposureKey *keys= payload.add_keys();
+            keys->set_key_data(key.keyData());
+            keys->set_rolling_start_interval_number(static_cast<qint32>(key.rollingStartNumber()));
+            keys->set_rolling_period(static_cast<qint32>(key.rollingPeriod()));
+            keys->set_transmission_risk_level(key.transmissionRiskLevel());
+
+            QDateTime time;
+            time.setMSecsSinceEpoch(0);
+            QDate date = time.addSecs(key.rollingStartNumber() * 60 * 10).date();
+            if (date > m_latest) {
+                m_latest = date;
+                emit latestChanged();
+            }
+        }
+        qDebug() << "Keys included: " << payload.keys_size();
+
+        QByteArray data = QByteArray::fromStdString(payload.SerializeAsString());
+
+        request.setUrl(QUrl("http://" UPLOAD_SERVER_ADDRESS "/version/v1/diagnosis-keys"));
+        request.setRawHeader("accept", "*/*");
+        request.setRawHeader("Content-Type", "application/x-protobuf");
+        request.setRawHeader("cwa-authorization", tan.toLatin1());
+        request.setRawHeader("cwa-fake", "0");
+        m_reply = m_manager->post(request, data);
+        qDebug() << "Uploading";
+
+        m_bytesSent = 0;
+        m_bytesTotal = data.size();
+        connect(m_reply, &QNetworkReply::finished, this, &Upload::onDiagnosisKeysFinished);
+        connect(m_reply, &QNetworkReply::uploadProgress, this, &Upload::onProgress);
+        emit uploadingChanged();
+    }
+    else {
+        qDebug() << "Incorrect state attempting to submit diagnosis keys";
+        setStatus(StatusError);
+    }
+}
+
+void Upload::onDiagnosisKeysFinished()
+{
+    QNetworkReply *reply = m_reply;
+    m_reply = nullptr;
+
+    qDebug() << "Upload finished";
+
+    if (reply->error() == QNetworkReply::NoError) {
+        qDebug() << "Upload successful";
+        setStatus(StatusIdle);
+    }
+    else {
+        qDebug() << "Network error while submitting diagnosis keys: " << reply->errorString();
+        setStatus(StatusError);
+    }
+
+    reply->deleteLater();
+    emit uploadingChanged();
+}
+
+bool Upload::uploading() const
+{
+    return (m_reply != nullptr);
+}
+
+float Upload::progress() const
+{
+    float progress = 0.0f;
+
+    if (m_bytesTotal > 0.0f) {
+        progress = static_cast<float>(m_bytesSent) / static_cast<float>(m_bytesTotal);
+    }
+
+    return progress;
+}
+
+Upload::Status Upload::status() const
+{
+    return m_status;
+}
+
+void Upload::setStatus(Status status)
+{
+    if (m_status != status) {
+        qDebug() << "Setting status: " << status;
+        m_status = status;
+        emit statusChanged();
+    }
+}
+
+void Upload::onProgress(qint64 bytesSent, qint64 bytesTotal)
+{
+    qDebug() << "CONTRAC: bytes sent: " << bytesSent;
+    qDebug() << "CONTRAC: bytes total: " << bytesTotal;
+
+    m_bytesSent = bytesSent;
+    m_bytesTotal = bytesTotal;
+
+    emit progressChanged();
+}
+
+QDate Upload::latest() const
+{
+    return m_latest;
+}
+
+bool Upload::validateTeleTAN(QString const &teleTAN)
+{
+    static const uint16_t length = 10;
+    bool result;
+    QByteArray data;
+
+    qDebug() << "Validating teleTAN: " << teleTAN;
+    result = teleTAN.length() == length;
+
+    qDebug() << "Valid Length: " << result;
+
+    for (uint16_t pos = 0; pos < length && result; ++pos) {
+        result &= validateTeleTANCharacter(teleTAN.at(pos));
+    }
+
+    qDebug() << "Valid characters: " << result;
+
+    if (result) {
+        EVP_MD_CTX *context;
+        char hash[EVP_MAX_MD_SIZE];
+        unsigned int hashLength;
+
+        context = EVP_MD_CTX_create();
+        EVP_DigestInit_ex(context, EVP_sha256(), nullptr);
+        data = teleTAN.left(length - 1).toLatin1();
+        EVP_DigestUpdate(context, data.data(), static_cast<unsigned int>(data.length()));
+
+        EVP_DigestFinal_ex(context, reinterpret_cast<unsigned char *>(hash), &hashLength);
+        EVP_MD_CTX_destroy(context);
+
+        result = hashLength > 0;
+
+        if (result) {
+            QChar hashCheck = QByteArray(hash, static_cast<int>(hashLength)).toHex().at(0);
+            if (hashCheck == '0') {
+                hashCheck = 'g';
+            }
+            if (hashCheck == '1') {
+                hashCheck = 'h';
+            }
+            result = (teleTAN.at(length - 1).toLower() == hashCheck);
+
+            qDebug() << "Valid checksum: " << result;
+        }
+    }
+
+    return result;
+}
+
+bool Upload::validateTeleTANCharacter(QChar const &character)
+{
+    static const QString validChars = "23456789ABCDEFGHJKMNPQRSTUVWXYZ";
+
+    return validChars.contains(character, Qt::CaseInsensitive);
+}

--- a/src/upload.h
+++ b/src/upload.h
@@ -1,0 +1,66 @@
+#ifndef UPLOAD_H
+#define UPLOAD_H
+
+#include <QObject>
+#include <QNetworkReply>
+
+#include "dbusproxy.h"
+#include "contracd/src/temporaryexposurekey.h"
+
+class Upload : public QObject
+{
+    Q_OBJECT
+    Q_ENUMS(Status)
+    Q_PROPERTY(QDate latest READ latest NOTIFY latestChanged)
+    Q_PROPERTY(bool uploading READ uploading NOTIFY uploadingChanged)
+    Q_PROPERTY(float progress READ progress NOTIFY progressChanged)
+    Q_PROPERTY(Status status READ status NOTIFY statusChanged)
+
+public:
+    enum Status
+    {
+        StatusIdle,
+        StatusSubmitTeleTAN,
+        StatusSubmitRegToken,
+        SubmitDiagnosisKeys,
+        StatusError
+    };
+    explicit Upload(QObject *parent = nullptr);
+
+    Q_INVOKABLE void upload(QString const &teleTAN);
+    Q_INVOKABLE bool validateTeleTAN(QString const &teleTAN);
+    Q_INVOKABLE bool validateTeleTANCharacter(QChar const &character);
+    float progress() const;
+    bool uploading() const;
+    QDate latest() const;
+    Status status() const;
+
+signals:
+    void uploadComplete();
+    void progressChanged();
+    void uploadingChanged();
+    void latestChanged();
+    void statusChanged();
+
+public slots:
+    void setStatus(Status status);
+    void onTeleTANFinished();
+    void onRegTokenFinished();
+    void onDiagnosisKeysFinished();
+    void onProgress(qint64 bytesSent, qint64 bytesTotal);
+
+private:
+    void submitTeleTAN(QString const &teleTAN);
+    void submitRegToken(QString const &regToken);
+    void submitDiagnosisKeys(QString const &tan);
+
+private:
+    QNetworkAccessManager *m_manager;
+    QNetworkReply *m_reply;
+    QDate m_latest;
+    qint64 m_bytesSent;
+    qint64 m_bytesTotal;
+    Status m_status;
+};
+
+#endif // UPLOAD_H

--- a/translations/harbour-contrac-en.ts
+++ b/translations/harbour-contrac-en.ts
@@ -4,85 +4,87 @@
 <context>
     <name></name>
     <message id="contrac-cover_title">
-        <location filename="../qml/cover/CoverPage.qml" line="9"/>
         <source>Contrac</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_title">
-        <location filename="../qml/pages/About.qml" line="24"/>
         <source>About Contact Tracer</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_description">
-        <location filename="../qml/pages/About.qml" line="29"/>
         <source>Demonstration of the Apple/Google Contract Tracing API</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_verion">
-        <location filename="../qml/pages/About.qml" line="42"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_app_author">
-        <location filename="../qml/pages/About.qml" line="51"/>
         <source>App author</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_app_author_name">
-        <location filename="../qml/pages/About.qml" line="53"/>
         <source>David Llewellyn-Jones</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_licence">
-        <location filename="../qml/pages/About.qml" line="61"/>
         <source>Licence</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_gpl_v2">
-        <location filename="../qml/pages/About.qml" line="63"/>
         <source>GPLv2</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_header_links">
-        <location filename="../qml/pages/About.qml" line="71"/>
         <source>Links</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_website">
-        <location filename="../qml/pages/About.qml" line="80"/>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_email">
-        <location filename="../qml/pages/About.qml" line="87"/>
         <source>Email</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-main_about">
-        <location filename="../qml/pages/Main.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-main_title">
-        <location filename="../qml/pages/Main.qml" line="49"/>
         <source>BLE Contact Tracing</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="contrac-main_contact_beacons">
+        <source>Contact beacons</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="contrac-main_scan">
-        <location filename="../qml/pages/Main.qml" line="54"/>
         <source>Scan and send active</source>
-        <oldsource>Scan and transmit</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-main_sent">
-        <location filename="../qml/pages/Main.qml" line="74"/>
         <source>Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-main_received">
-        <location filename="../qml/pages/Main.qml" line="82"/>
         <source>Received</source>
-        <oldsource>Beacons received</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_diagnosis_key_uploadss">
+        <source>Diagnosis key uploads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_diagnosis_key_downloads">
+        <source>Diagnosis key downloads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_using_google_apple_api">
+        <source>Using the Google/Apple API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_using_corona_warn_app_servers">
+        <source>Using the Corona Warn App servers</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-contrac-zh_CN.ts
+++ b/translations/harbour-contrac-zh_CN.ts
@@ -4,86 +4,90 @@
 <context>
     <name></name>
     <message id="contrac-cover_title">
-        <location filename="../qml/cover/CoverPage.qml" line="9"/>
         <source>Contrac</source>
         <translation>Contrac</translation>
     </message>
     <message id="contrac-about_title">
-        <location filename="../qml/pages/About.qml" line="24"/>
         <source>About Contact Tracer</source>
         <translation>关于接触追踪器</translation>
     </message>
     <message id="contrac-about_description">
-        <location filename="../qml/pages/About.qml" line="29"/>
         <source>Demonstration of the Apple/Google Contract Tracing API</source>
         <translation>苹果/谷歌 示例接触追踪API</translation>
     </message>
     <message id="contrac-about_verion">
-        <location filename="../qml/pages/About.qml" line="42"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message id="contrac-about_app_author">
-        <location filename="../qml/pages/About.qml" line="51"/>
         <source>App author</source>
         <translation>软件开发者</translation>
     </message>
     <message id="contrac-about_app_author_name">
-        <location filename="../qml/pages/About.qml" line="53"/>
         <source>David Llewellyn-Jones</source>
         <translation>David Llewellyn-Jones</translation>
     </message>
     <message id="contrac-about_licence">
-        <location filename="../qml/pages/About.qml" line="61"/>
         <source>Licence</source>
         <translation>许可证</translation>
     </message>
     <message id="contrac-about_gpl_v2">
-        <location filename="../qml/pages/About.qml" line="63"/>
         <source>GPLv2</source>
         <translation>GPLv2</translation>
     </message>
     <message id="contrac-about_header_links">
-        <location filename="../qml/pages/About.qml" line="71"/>
         <source>Links</source>
         <translation>链接</translation>
     </message>
     <message id="contrac-about_website">
-        <location filename="../qml/pages/About.qml" line="80"/>
         <source>Website</source>
         <translation>网址</translation>
     </message>
     <message id="contrac-about_email">
-        <location filename="../qml/pages/About.qml" line="87"/>
         <source>Email</source>
         <translation>电子邮箱</translation>
     </message>
     <message id="contrac-main_about">
-        <location filename="../qml/pages/Main.qml" line="37"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message id="contrac-main_title">
-        <location filename="../qml/pages/Main.qml" line="49"/>
         <source>BLE Contact Tracing</source>
         <translation>BLE接触追踪</translation>
     </message>
     <message id="contrac-main_scan">
-        <location filename="../qml/pages/Main.qml" line="54"/>
         <source>Scan and send active</source>
         <oldsource>Scan and transmit</oldsource>
         <translation>扫描及发送活动</translation>
     </message>
     <message id="contrac-main_sent">
-        <location filename="../qml/pages/Main.qml" line="74"/>
         <source>Sent</source>
         <translation>发送</translation>
     </message>
     <message id="contrac-main_received">
-        <location filename="../qml/pages/Main.qml" line="82"/>
         <source>Received</source>
         <oldsource>Beacons received</oldsource>
         <translation>接收</translation>
+    </message>
+    <message id="contrac-main_contact_beacons">
+        <source>Contact beacons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_diagnosis_key_uploadss">
+        <source>Diagnosis key uploads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_diagnosis_key_downloads">
+        <source>Diagnosis key downloads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_using_google_apple_api">
+        <source>Using the Google/Apple API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_using_corona_warn_app_servers">
+        <source>Using the Corona Warn App servers</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-contrac.ts
+++ b/translations/harbour-contrac.ts
@@ -4,85 +4,87 @@
 <context>
     <name></name>
     <message id="contrac-cover_title">
-        <location filename="../qml/cover/CoverPage.qml" line="9"/>
         <source>Contrac</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_title">
-        <location filename="../qml/pages/About.qml" line="24"/>
         <source>About Contact Tracer</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_description">
-        <location filename="../qml/pages/About.qml" line="29"/>
         <source>Demonstration of the Apple/Google Contract Tracing API</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_verion">
-        <location filename="../qml/pages/About.qml" line="42"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_app_author">
-        <location filename="../qml/pages/About.qml" line="51"/>
         <source>App author</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_app_author_name">
-        <location filename="../qml/pages/About.qml" line="53"/>
         <source>David Llewellyn-Jones</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_licence">
-        <location filename="../qml/pages/About.qml" line="61"/>
         <source>Licence</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_gpl_v2">
-        <location filename="../qml/pages/About.qml" line="63"/>
         <source>GPLv2</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_header_links">
-        <location filename="../qml/pages/About.qml" line="71"/>
         <source>Links</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_website">
-        <location filename="../qml/pages/About.qml" line="80"/>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-about_email">
-        <location filename="../qml/pages/About.qml" line="87"/>
         <source>Email</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-main_about">
-        <location filename="../qml/pages/Main.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-main_title">
-        <location filename="../qml/pages/Main.qml" line="49"/>
         <source>BLE Contact Tracing</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="contrac-main_contact_beacons">
+        <source>Contact beacons</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="contrac-main_scan">
-        <location filename="../qml/pages/Main.qml" line="54"/>
         <source>Scan and send active</source>
-        <oldsource>Scan and transmit</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-main_sent">
-        <location filename="../qml/pages/Main.qml" line="74"/>
         <source>Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-main_received">
-        <location filename="../qml/pages/Main.qml" line="82"/>
         <source>Received</source>
-        <oldsource>Beacons received</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_diagnosis_key_uploadss">
+        <source>Diagnosis key uploads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_diagnosis_key_downloads">
+        <source>Diagnosis key downloads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_using_google_apple_api">
+        <source>Using the Google/Apple API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_using_corona_warn_app_servers">
+        <source>Using the Corona Warn App servers</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Adds code to serialise the key data into a protobuffer and upload the result to a submissions server.

Still a work in progress, but when completed this'll fix #7.