### PR TITLE
Add persistent state to contracd

### DIFF
--- a/contracd/contracd.pro
+++ b/contracd/contracd.pro
@@ -44,6 +44,7 @@ HEADERS += \
     src/fnv.h \
     src/hkdfsha256.h \
     src/rpidataitem.h \
+    src/settings.h \
     src/temporaryexposurekey.h \
     src/zipistreambuffer.h
 
@@ -69,6 +70,7 @@ SOURCES += \
     src/fnv.cpp \
     src/hkdfsha256.cpp \
     src/rpidataitem.cpp \
+    src/settings.cpp \
     src/temporaryexposurekey.cpp \
     src/zipistreambuffer.cpp
 

--- a/contracd/src/dbusinterface.cpp
+++ b/contracd/src/dbusinterface.cpp
@@ -1,12 +1,12 @@
 #include <QDebug>
 
+#include "settings.h"
+
 #include "dbusinterface.h"
 
 DBusInterface::DBusInterface(QObject *parent)
     : QObject(parent)
     , m_connection(QDBusConnection::sessionBus())
-    , m_sentCount(0)
-    , m_receivedCount(0)
 {
     bool result;
 
@@ -37,6 +37,12 @@ DBusInterface::DBusInterface(QObject *parent)
 
     if (!result) {
         qDebug() << "CONTRAC: Error initialising dbus interface";
+    }
+
+    Settings &settings = Settings::getInstance();
+    if (settings.enabled()) {
+        qDebug() << "Starting automatically";
+        m_exposureNotification.start();
     }
 }
 
@@ -136,27 +142,27 @@ void DBusInterface::resetAllData()
 
 quint32 DBusInterface::receivedCount() const
 {
-    return m_receivedCount;
+    return Settings::getInstance().received();
 }
 
 quint32 DBusInterface::sentCount() const
 {
-    return m_sentCount;
+    return Settings::getInstance().sent();
 }
 
 void DBusInterface::incrementReceiveCount()
 {
     qDebug() << "CONTRAC: incrementReceiveCount()";
-    ++m_receivedCount;
-    qDebug() << "CONTRAC: receiveCount:" << m_receivedCount;
+    Settings &settings = Settings::getInstance();
+    settings.setReceived(settings.received() + 1);
     emit receivedCountChanged();
 }
 
 void DBusInterface::incrementSentCount()
 {
     qDebug() << "CONTRAC: incrementSentCount()";
-    ++m_sentCount;
-    qDebug() << "CONTRAC: receiveCount:" << m_sentCount;
+    Settings &settings = Settings::getInstance();
+    settings.setSent(settings.sent() + 1);
     emit sentCountChanged();
 }
 

--- a/contracd/src/dbusinterface.h
+++ b/contracd/src/dbusinterface.h
@@ -63,9 +63,6 @@ private slots:
 private:
     QDBusConnection m_connection;
     ExposureNotification m_exposureNotification;
-
-    quint32 m_sentCount;
-    quint32 m_receivedCount;
 };
 
 

--- a/contracd/src/exposurenotification_p.h
+++ b/contracd/src/exposurenotification_p.h
@@ -12,8 +12,9 @@ namespace diagnosis {
 class TemporaryExposureKeyExport;
 } // namespace diagnosis
 
-class ExposureNotificationPrivate
+class ExposureNotificationPrivate : public QObject
 {
+    Q_OBJECT
 public:
     explicit ExposureNotificationPrivate(ExposureNotification *q);
     ~ExposureNotificationPrivate();
@@ -26,6 +27,9 @@ private:
     ExposureNotification *q_ptr;
 
     Q_DECLARE_PUBLIC(ExposureNotification)
+
+public slots:
+    void scanChanged();
 
 public:
     QMap<QString, QList<ExposureInformation>> m_exposures;

--- a/contracd/src/settings.cpp
+++ b/contracd/src/settings.cpp
@@ -1,0 +1,92 @@
+#include <QDebug>
+
+#include "settings.h"
+
+Settings * Settings::instance = nullptr;
+
+Settings::Settings(QObject *parent) : QObject(parent),
+    settings(this)
+{
+    m_tracingKey = settings.value(QStringLiteral("keys/tracingKey"), QVariant(QByteArray())).toByteArray();
+    m_enabled = settings.value(QStringLiteral("state/enabled"), false).toBool();
+    m_sent = settings.value(QStringLiteral("state/sent"), 0).toUInt();
+    m_received = settings.value(QStringLiteral("state/received"), 0).toUInt();
+
+    qDebug() << "Settings created: " << settings.fileName();
+}
+
+Settings::~Settings()
+{
+    settings.setValue(QStringLiteral("keys/tracingKey"), m_tracingKey);
+    settings.setValue(QStringLiteral("state/enabled"), m_enabled);
+    settings.setValue(QStringLiteral("state/sent"), m_sent);
+    settings.setValue(QStringLiteral("state/received"), m_received);
+
+    qDebug() << "Deleted settings";
+}
+
+void Settings::instantiate(QObject *parent) {
+    if (instance == nullptr) {
+        instance = new Settings(parent);
+    }
+}
+
+Settings & Settings::getInstance() {
+    return *instance;
+}
+
+Q_INVOKABLE QByteArray Settings::tracingKey() const
+{
+    return m_tracingKey;
+}
+
+void Settings::setTracingKey(QByteArray const &tracingKey)
+{
+    if (m_tracingKey != tracingKey) {
+        m_tracingKey = tracingKey;
+
+        emit tracingKeyChanged();
+    }
+}
+
+Q_INVOKABLE bool Settings::enabled() const
+{
+    return m_enabled;
+}
+
+void Settings::setEnabled(bool enabled)
+{
+    if (m_enabled != enabled) {
+        m_enabled = enabled;
+
+        emit enabledChanged();
+    }
+}
+
+Q_INVOKABLE quint32 Settings::sent() const
+{
+    return m_sent;
+}
+
+void Settings::setSent(quint32 sent)
+{
+    if (m_sent != sent) {
+        m_sent = sent;
+
+        emit sentChanged();
+    }
+}
+
+Q_INVOKABLE quint32 Settings::received() const
+{
+    return m_received;
+}
+
+void Settings::setReceived(quint32 received)
+{
+    if (m_received != received) {
+        m_received = received;
+
+        emit receivedChanged();
+    }
+}

--- a/contracd/src/settings.h
+++ b/contracd/src/settings.h
@@ -1,0 +1,51 @@
+#ifndef CONTRACD_SETTINGS_H
+#define CONTRACD_SETTINGS_H
+
+#include <QObject>
+#include <QSettings>
+
+class Settings : public QObject
+{
+    Q_OBJECT
+
+    // General properties
+    Q_PROPERTY(QByteArray tracingKey READ tracingKey WRITE setTracingKey NOTIFY tracingKeyChanged)
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
+    Q_PROPERTY(quint32 sent READ sent WRITE setSent NOTIFY sentChanged)
+    Q_PROPERTY(quint32 received READ received WRITE setReceived NOTIFY receivedChanged)
+
+public:
+    explicit Settings(QObject *parent = nullptr);
+    ~Settings();
+
+    static void instantiate(QObject *parent = nullptr);
+    static Settings & getInstance();
+
+    Q_INVOKABLE QByteArray tracingKey() const;
+    Q_INVOKABLE bool enabled() const;
+    Q_INVOKABLE quint32 sent() const;
+    Q_INVOKABLE quint32 received() const;
+
+signals:
+    void tracingKeyChanged();
+    void enabledChanged();
+    void sentChanged();
+    void receivedChanged();
+
+public slots:
+    void setTracingKey(QByteArray const &tracingKey);
+    void setEnabled(bool enabled);
+    void setSent(quint32 sent);
+    void setReceived(quint32 received);
+
+private:
+    static Settings * instance;
+    QSettings settings;
+
+    QByteArray m_tracingKey;
+    bool m_enabled;
+    quint32 m_sent;
+    quint32 m_received;
+};
+
+#endif // CONTRACD_SETTINGS_H

--- a/src/harbour-contrac.cpp
+++ b/src/harbour-contrac.cpp
@@ -30,9 +30,15 @@ int main(int argc, char *argv[])
 
     QGuiApplication *app = SailfishApp::application(argc, argv);
     QCoreApplication::setOrganizationDomain("www.flypig.co.uk");
+    QCoreApplication::setOrganizationName("harbour-contrac");
     QCoreApplication::setApplicationName("harbour-contrac");
 
-    Settings::instantiate();
+    qDebug() << "harbour-getiplay VERSION string:" << VERSION;
+    qDebug() << "VERSION_MAJOR:" << VERSION_MAJOR;
+    qDebug() << "VERSION_MINOR:" << VERSION_MINOR;
+    qDebug() << "VERSION_BUILD:" << VERSION_BUILD;
+
+    Settings::instantiate(app);
 
     qmlRegisterType<DBusProxy>("uk.co.flypig.contrac", 1, 0, "DBusProxy");
     qmlRegisterType<TemporaryExposureKey>("uk.co.flypig.contrac", 1, 0, "TemporaryExposureKey");
@@ -48,16 +54,12 @@ int main(int argc, char *argv[])
     view->setSource(SailfishApp::pathTo("qml/harbour-contrac.qml"));
     QQmlContext *ctxt = view->rootContext();
     ctxt->setContextProperty("version", VERSION);
-    qDebug() << "harbour-getiplay VERSION string: " << VERSION;
-    qDebug() << "VERSION_MAJOR: " << VERSION_MAJOR;
-    qDebug() << "VERSION_MINOR: " << VERSION_MINOR;
-    qDebug() << "VERSION_BUILD: " << VERSION_BUILD;
 
     view->show();
 
     int result = app->exec();
 
-    qDebug() << "Execution finished: " << result;
+    qDebug() << "Execution finished:" << result;
     delete view;
     qDebug() << "Deleted view";
     delete app;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -11,7 +11,7 @@ Settings::Settings(QObject *parent) : QObject(parent),
     m_uploadServer = settings.value(QStringLiteral("servers/uploadServer"), QStringLiteral("127.0.0.1:8000")).toString();
     m_verificationServer = settings.value(QStringLiteral("servers/verificationServer"), QStringLiteral("127.0.0.1:8004")).toString();
 
-    qDebug() << "Settings created";
+    qDebug() << "Settings created: " << settings.fileName();
 }
 
 Settings::~Settings()
@@ -20,7 +20,7 @@ Settings::~Settings()
     settings.setValue(QStringLiteral("servers/uploadServer"), m_uploadServer);
     settings.setValue(QStringLiteral("servers/verificationServer"), m_verificationServer);
 
-    qDebug() << "Settings deleted";
+    qDebug() << "Deleted settings";
 }
 
 void Settings::instantiate(QObject *parent) {

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -59,8 +59,9 @@ HEADERS += \
     ../contracd/src/fnv.h \
     ../contracd/src/hkdfsha256.h \
     ../contracd/src/rpidataitem.h \
+    ../contracd/src/settings.h \
     ../contracd/src/temporaryexposurekey.h \
-    ../contracd/src/zipistreambuffer.h \
+    ../contracd/src/zipistreambuffer.h
 
 SOURCES += \
     ../src/contactmodel.cpp \
@@ -83,8 +84,9 @@ SOURCES += \
     ../contracd/src/fnv.cpp \
     ../contracd/src/hkdfsha256.cpp \
     ../contracd/src/rpidataitem.cpp \
+    ../contracd/src/settings.cpp \
     ../contracd/src/temporaryexposurekey.cpp \
-    ../contracd/src/zipistreambuffer.cpp \
+    ../contracd/src/zipistreambuffer.cpp
 
 INCLUDEPATH += $$OUT_PWD/../contracd/proto
 


### PR DESCRIPTION
Adds a Settings class to contracd to persistently store settings and
state. Records the send and received counts, as well as the enabled
state. The daemon will automatically restart scanning and advertising if
the enabled flag is set in the configuration.

Contributes to #16.