### PR TITLE
Add encrypted metadata to beacons

### DIFF
--- a/contracd/contracd.pro
+++ b/contracd/contracd.pro
@@ -23,11 +23,11 @@ CONFIG += sailfishapp
 
 HEADERS += \
     proto/contrac.pb.h \
+    src/blescanner.h \
     src/contracd.h \
     src/dbusinterface.h \
     src/bleadvertisement.h \
     src/bleadvertisementmanager.h \
-    src/bleascanner.h \
     src/bloomfilter.h \
     src/contactinterval.h \
     src/contactmatch.h \
@@ -43,6 +43,7 @@ HEADERS += \
     src/exposuresummary.h \
     src/fnv.h \
     src/hkdfsha256.h \
+    src/metadata.h \
     src/rpidataitem.h \
     src/settings.h \
     src/temporaryexposurekey.h \
@@ -69,6 +70,7 @@ SOURCES += \
     src/exposuresummary.cpp \
     src/fnv.cpp \
     src/hkdfsha256.cpp \
+    src/metadata.cpp \
     src/rpidataitem.cpp \
     src/settings.cpp \
     src/temporaryexposurekey.cpp \

--- a/contracd/src/blescanner.cpp
+++ b/contracd/src/blescanner.cpp
@@ -3,7 +3,7 @@
 #include <QDBusArgument>
 #include <QDBusMetaType>
 
-#include "bleascanner.h"
+#include "blescanner.h"
 
 BleScanner::BleScanner(QObject *parent) : QObject(parent)
   , m_adapterInterface(nullptr)

--- a/contracd/src/blescanner.h
+++ b/contracd/src/blescanner.h
@@ -25,7 +25,7 @@ public:
 signals:
     void scanChanged();
     void busyChanged();
-    void beaconDiscovered(const QString &address, const QByteArray &rpi, qint16 rssi);
+    void beaconDiscovered(const QString &address, const QByteArray &data, qint16 rssi);
 
 private:
     enum ScanState {

--- a/contracd/src/contactstorage.cpp
+++ b/contracd/src/contactstorage.cpp
@@ -42,9 +42,9 @@ void ContactStorage::onTimeChanged()
     }
 }
 
-void ContactStorage::addContact(ctinterval interval, const QByteArray &rpi, qint16 rssi)
+void ContactStorage::addContact(ctinterval interval, const QByteArray &rpi, const QByteArray &aem, qint16 rssi)
 {
-    m_today->addContact(interval, rpi, rssi);
+    m_today->addContact(interval, rpi, aem, rssi);
 }
 
 void ContactStorage::dumpData(quint32 day)

--- a/contracd/src/contactstorage.h
+++ b/contracd/src/contactstorage.h
@@ -30,7 +30,7 @@ public:
 signals:
 
 public slots:
-    Q_INVOKABLE void addContact(ctinterval interval, const QByteArray &rpi, qint16 rssi);
+    Q_INVOKABLE void addContact(ctinterval interval, const QByteArray &rpi, const QByteArray &aem, qint16 rssi);
     void dumpData(quint32 day = 0);
     void onTimeChanged();
 

--- a/contracd/src/controller.cpp
+++ b/contracd/src/controller.cpp
@@ -18,7 +18,7 @@ Controller::Controller(QObject *parent) : QObject(parent)
     QVariantMap data;
     data.insert("0000fd6f-0000-1000-8000-00805f9b34fb", QByteArray("Hello"));
     m_bleadvert->setServiceData(data);
-    m_bleadvert->setLocalName(QStringLiteral("flypig"));
+    //m_bleadvert->setLocalName(QStringLiteral("flypig"));
     m_bleadvert->setDuration(10 * 60);
     m_bleadvert->setTimeout(10 * 60);
 
@@ -56,20 +56,24 @@ void Controller::unRegisterAdvert()
     }
 }
 
-void Controller::setRpi(QByteArray rpi)
+void Controller::setAdvertData(QByteArray const &rpi, QByteArray const &metadata)
 {
     bool registered = m_registered;
+    QByteArray serviceData;
 
     if (registered) {
         qDebug() << "CONTRAC: unregistering";
         unRegisterAdvert();
     }
+    serviceData = rpi;
+    serviceData.append(metadata);
+
     QVariantMap data;
-    data.insert("0000fd6f-0000-1000-8000-00805f9b34fb", rpi);
+    data.insert("0000fd6f-0000-1000-8000-00805f9b34fb", metadata);
     m_bleadvert->setServiceData(data);
-    QString rpiName(rpi.toHex());
-    rpiName.truncate(16);
-    m_bleadvert->setLocalName(rpiName);
+//    QString rpiName(rpi.toHex());
+//    rpiName.truncate(16);
+//    m_bleadvert->setLocalName(rpiName);
     if (registered) {
         registerAdvert();
     }

--- a/contracd/src/controller.h
+++ b/contracd/src/controller.h
@@ -26,7 +26,7 @@ public:
     Q_INVOKABLE void registerAdvert();
     Q_INVOKABLE void unRegisterAdvert();
 
-    Q_INVOKABLE void setRpi(QByteArray rpi);
+    Q_INVOKABLE void setAdvertData(QByteArray const &rpi, QByteArray const &metadata);
     Q_INVOKABLE static QString binaryToHex(QByteArray binary, int lineLength);
 
     bool active() const;

--- a/contracd/src/daystorage.h
+++ b/contracd/src/daystorage.h
@@ -19,7 +19,7 @@ public:
     QList<RpiDataItem> findRpiMatches(QList<QByteArray> const &rpis);
     QList<ContactMatch> findDtkMatches(QList<DiagnosisKey> const &dtks);
 
-    void addContact(ctinterval interval, const QByteArray &rpi, qint16 rssi);
+    void addContact(ctinterval interval, const QByteArray &rpi, const QByteArray &aem, qint16 rssi);
     void load();
     void save();
     quint32 dayNumber() const;

--- a/contracd/src/diagnosiskey.cpp
+++ b/contracd/src/diagnosiskey.cpp
@@ -2,13 +2,13 @@
 
 DiagnosisKey::DiagnosisKey()
     : m_dtk()
-    , m_transmissionRiskLevel(0)
+    , m_transmissionRiskLevel(RiskLevelMedium)
     , m_rollingStartIntervalNumber(0)
     , m_rollingPeriod(0)
 {
 }
 
-DiagnosisKey::DiagnosisKey(QByteArray const &dtk, quint32 transmissionRiskLevel, quint32 rollingStartIntervalNumber, quint32 rollingPeriod)
+DiagnosisKey::DiagnosisKey(QByteArray const &dtk, RiskLevel transmissionRiskLevel, quint32 rollingStartIntervalNumber, quint32 rollingPeriod)
     : m_dtk(dtk)
     , m_transmissionRiskLevel(transmissionRiskLevel)
     , m_rollingStartIntervalNumber(rollingStartIntervalNumber)

--- a/contracd/src/diagnosiskey.h
+++ b/contracd/src/diagnosiskey.h
@@ -6,11 +6,23 @@
 class DiagnosisKey
 {
 public:
+    enum RiskLevel : quint32 {
+        RiskLevelInvalid = 0,
+        RiskLevelLowest = 1,
+        RiskLevelLow = 2,
+        RiskLevelLowMedium = 3,
+        RiskLevelMedium = 4,
+        RiskLevelMediumHigh = 5,
+        RiskLevelHigh = 6,
+        RiskLevelVeryHigh = 7,
+        RiskLevelHighest = 8
+    };
+
     DiagnosisKey();
-    DiagnosisKey(QByteArray const &dtk, quint32 transmissionRiskLevel, quint32 rollingStartIntervalNumber, quint32 rollingPeriod);
+    DiagnosisKey(QByteArray const &dtk, RiskLevel transmissionRiskLevel, quint32 rollingStartIntervalNumber, quint32 rollingPeriod);
 
     QByteArray m_dtk;
-    quint32 m_transmissionRiskLevel;
+    RiskLevel m_transmissionRiskLevel;
     quint32 m_rollingStartIntervalNumber;
     quint32 m_rollingPeriod;
 };

--- a/contracd/src/exposureconfiguration.cpp
+++ b/contracd/src/exposureconfiguration.cpp
@@ -1,7 +1,18 @@
 #include "exposureconfiguration.h"
 
 
-ExposureConfiguration::ExposureConfiguration(QObject *parent) : QObject(parent)
+ExposureConfiguration::ExposureConfiguration(QObject *parent)
+    : QObject(parent)
+    , m_minimumRiskScore(0)
+    , m_attenuationScores({0, 1, 2, 3, 4, 5, 6, 7})
+    , m_daysSinceLastExposureScores({0, 1, 2, 3, 4, 5, 6, 7})
+    , m_durationScores({0, 1, 2, 3, 4, 5, 6, 7})
+    , m_transmissionRiskScores({0, 1, 2, 3, 4, 5, 6, 7})
+    , m_attenuationWeight(1.0)
+    , m_daysSinceLastExposureWeight(1.0)
+    , m_durationWeight(1.0)
+    , m_transmissionRiskWeight(1.0)
+    , m_durationAtAttenuationThresholds({8, 64})
 {
 }
 

--- a/contracd/src/exposurenotification.h
+++ b/contracd/src/exposurenotification.h
@@ -13,7 +13,7 @@
 #include "exposureconfiguration.h"
 #include "temporaryexposurekey.h"
 #include "contrac.h"
-#include "bleascanner.h"
+#include "blescanner.h"
 #include "controller.h"
 #include "contactstorage.h"
 
@@ -65,7 +65,7 @@ signals:
     void beaconReceived();
 
 public slots:
-    void beaconDiscovered(const QString &address, const QByteArray &rpi, qint16 rssi);
+    void beaconDiscovered(const QString &address, const QByteArray &data, qint16 rssi);
     void intervalUpdate();
     void onRpiChanged();
 

--- a/contracd/src/exposurenotification_p.h
+++ b/contracd/src/exposurenotification_p.h
@@ -6,6 +6,7 @@
 
 #include "exposureinformation.h"
 #include "contrac.h"
+#include "metadata.h"
 #include "exposurenotification.h"
 
 namespace diagnosis {
@@ -20,7 +21,7 @@ public:
     ~ExposureNotificationPrivate();
 
     static bool loadDiagnosisKeys(QString const &keyFile, diagnosis::TemporaryExposureKeyExport * keyExport);
-    QList<ExposureInformation> aggregateExposureData(quint32 dayNumber, ExposureConfiguration const &configuration, QList<ContactMatch> matches);
+    static QList<ExposureInformation> aggregateExposureData(quint32 dayNumber, ExposureConfiguration const &configuration, QList<ContactMatch> matches, qint32 const days_ago);
     static quint32 calculateRiskScore(ExposureConfiguration const &configuration, qint32 transmissionRisk, qint32 duration, qint32 days_ago, qint32 attenuationValue);
 
 private:
@@ -38,6 +39,7 @@ public:
     BleScanner *m_scanner;
     Controller *m_controller;
     ContactStorage *m_contacts;
+    Metadata m_metadata;
     QTimer m_intervalUpdate;
 };
 

--- a/contracd/src/metadata.cpp
+++ b/contracd/src/metadata.cpp
@@ -1,0 +1,262 @@
+#include <QDebug>
+#include <openssl/crypto.h>
+#include <openssl/evp.h>
+
+#include "hkdfsha256.h"
+
+#include "metadata.h"
+
+#define AEMK_SIZE (16u)
+#define AEMK_INFO "EN-AEMK"
+#define AEM_VERSION (0b01000000)
+
+Metadata::Metadata()
+    : m_dtk()
+    , m_rpi()
+    , m_txPower(TX_POWER_UNKNOWN)
+    , m_aem()
+    , m_needsEncrypting(true)
+    , m_needsDecrypting(false)
+    , m_valid(false)
+{
+
+}
+
+Metadata::Metadata(QByteArray const &dtk, QByteArray const &rpi, qint8 txPower)
+    : m_dtk(dtk)
+    , m_rpi(rpi)
+    , m_txPower(txPower)
+    , m_aem()
+    , m_needsEncrypting(true)
+    , m_needsDecrypting(false)
+    , m_valid(true)
+{
+}
+
+Metadata::Metadata(QByteArray const &aem)
+    : m_dtk()
+    , m_rpi()
+    , m_txPower()
+    , m_aem(aem)
+    , m_needsEncrypting(false)
+    , m_needsDecrypting(true)
+    , m_valid(true)
+{
+}
+
+void Metadata::setDtk(QByteArray const &dtk)
+{
+    if (m_dtk != dtk) {
+        m_dtk = dtk;
+        m_needsEncrypting = true;
+    }
+}
+
+void Metadata::setRpi(QByteArray const &rpi)
+{
+    if (m_rpi != rpi) {
+        m_rpi = rpi;
+        m_needsEncrypting = true;
+    }
+}
+
+void Metadata::setTxPower(qint8 txPower)
+{
+    if (m_txPower != txPower) {
+        if (m_needsDecrypting) {
+            decryptMetadata();
+        }
+        m_txPower = txPower;
+        m_needsEncrypting = true;
+    }
+}
+
+void Metadata::setEncryptedMetadata(QByteArray const &aem)
+{
+    if (m_aem != aem) {
+        m_aem = aem;
+        m_needsDecrypting = true;
+    }
+}
+
+qint8 Metadata::txPower()
+{
+    m_valid = true;
+    if (m_needsDecrypting) {
+        m_valid = decryptMetadata();
+    }
+
+    return m_valid ? m_txPower : TX_POWER_UNKNOWN;
+}
+
+QByteArray Metadata::metadata()
+{
+    QByteArray metadata;
+
+    m_valid = true;
+    if (m_needsDecrypting) {
+        m_valid = decryptMetadata();
+    }
+    if (m_valid) {
+        metadata.fill(0, 4);
+        metadata[0] = AEM_VERSION;
+        metadata[1] = static_cast<quint8>(m_txPower);
+    }
+
+    return metadata;
+}
+
+QByteArray Metadata::encryptedMetadata()
+{
+    m_valid = true;
+    if (m_needsEncrypting) {
+        m_valid = encryptMetadata();
+    }
+
+    return m_valid ? m_aem : QByteArray();
+}
+
+bool Metadata::valid() const
+{
+    return m_valid;
+}
+
+
+bool Metadata::encryptMetadata()
+{
+    QByteArray const metadata = this->metadata();
+    int result;
+    unsigned char aemk[AEMK_SIZE];
+    unsigned int out_length = 0;
+    unsigned char const * dtk_data;
+    unsigned char const * rpi_data;
+    unsigned char salt[4];
+    unsigned char encode[sizeof(AEMK_INFO)];
+    int aem_length = 0;
+    unsigned char aem_data[AEM_SIZE];
+    EVP_CIPHER_CTX *ctx;
+
+    m_aem.clear();
+
+    // AEMK_i = HKDF(tek_i, NULL, UTF8("EN-AEMK"), 16)
+    // FORMAT: Output = HKDF(Key, Salt, Info, OutputLength )
+    dtk_data = reinterpret_cast<unsigned char const *>(m_dtk.data());
+    out_length = AEMK_SIZE;
+    memcpy(encode, AEMK_INFO, sizeof(AEMK_INFO));
+    result = HKDF(aemk, out_length, EVP_sha256(), dtk_data, static_cast<size_t>(m_dtk.size()), salt, 0, encode, sizeof(encode));
+
+    // Associated Encrypted Metadata_{i, j} = AES_128-CTR(AEMK_i, RPI_{i, j}, Metadata)
+    // FORMAT: Ciphertext = AES_128-CTR(Key, IV, Data)
+    ctx = EVP_CIPHER_CTX_new();
+    if (result > 0) {
+        rpi_data = reinterpret_cast<unsigned char const *>(m_rpi.data());
+        unsigned char const *key = aemk;
+        unsigned char const *iv = rpi_data;
+        unsigned char const *data = reinterpret_cast<unsigned char const *>(metadata.data());
+
+        EVP_EncryptInit_ex(ctx, EVP_aes_128_ctr(), nullptr, key, iv);
+
+        aem_length = AEM_SIZE;
+        result = EVP_EncryptUpdate(ctx, aem_data, &aem_length, data, metadata.length());
+    }
+    else {
+        qDebug() << "Error generating metadata key";
+    }
+
+    if ((result > 0) && (aem_length == AEM_SIZE)) {
+        int final_length = 0;
+        result = EVP_EncryptFinal_ex(ctx, aem_data + aem_length, &final_length);
+        aem_length += final_length;
+    }
+    else {
+        qDebug() << "Error encrypting metadata";
+    }
+
+    if ((result > 0) && (aem_length == AEM_SIZE)) {
+        m_aem = QByteArray(reinterpret_cast<char const *>(aem_data), aem_length);
+        m_needsEncrypting = false;
+    }
+    else {
+        qDebug() << "Error finalising metadata encryption";
+    }
+
+    EVP_CIPHER_CTX_free(ctx);
+
+    return result;
+}
+
+bool Metadata::decryptMetadata()
+{
+    QByteArray metadata;
+    int result;
+    unsigned char aemk[AEMK_SIZE];
+    unsigned int out_length = 0;
+    unsigned char const * dtk_data;
+    unsigned char const * rpi_data;
+    unsigned char salt[4];
+    unsigned char encode[sizeof(AEMK_INFO)];
+    int data_length = 0;
+    unsigned char data[AEM_SIZE];
+    EVP_CIPHER_CTX *ctx;
+
+    // AEMK_i = HKDF(tek_i, NULL, UTF8("EN-AEMK"), 16)
+    // FORMAT: Output = HKDF(Key, Salt, Info, OutputLength )
+    dtk_data = reinterpret_cast<unsigned char const *>(m_dtk.data());
+    out_length = AEMK_SIZE;
+    memcpy(encode, AEMK_INFO, sizeof(AEMK_INFO));
+    result = HKDF(aemk, out_length, EVP_sha256(), dtk_data, static_cast<size_t>(m_dtk.size()), salt, 0, encode, sizeof(encode));
+
+    // Associated Encrypted Metadata_{i, j} = AES_128-CTR(AEMK_i, RPI_{i, j}, Metadata)
+    // FORMAT: Ciphertext = AES_128-CTR(Key, IV, Data)
+    ctx = EVP_CIPHER_CTX_new();
+    if (result > 0) {
+        rpi_data = reinterpret_cast<unsigned char const *>(m_rpi.data());
+        unsigned char const *key = aemk;
+        unsigned char const *iv = rpi_data;
+        unsigned char const *aem_data = reinterpret_cast<unsigned char const *>(m_aem.data());
+
+        EVP_DecryptInit_ex(ctx, EVP_aes_128_ctr(), nullptr, key, iv);
+
+        data_length = AEM_SIZE;
+        result = EVP_DecryptUpdate(ctx, data, &data_length, aem_data, m_aem.length());
+    }
+    else {
+        qDebug() << "Error generating metadata key";
+    }
+
+    if (result > 0) {
+        int final_length = 0;
+        result = EVP_DecryptFinal_ex(ctx, data + data_length, &final_length);
+        data_length += final_length;
+    }
+    else {
+        qDebug() << "Error decrypting aem";
+    }
+
+    if (result > 0) {
+        result = (data_length == AEM_SIZE) ? 1 : 0;
+    }
+    else {
+        qDebug() << "Error finalising metadata decryption";
+    }
+
+    if (result > 0) {
+        // Check validity
+        result = ((data[0] == AEM_VERSION) && (data[2] == 0) && (data[3] == 0)) ? 1 : 0;
+    }
+    else {
+        qDebug() << "Decrypted data of incorrect length";
+    }
+
+    if (result) {
+        m_txPower = data[1];
+        m_needsDecrypting = false;
+    }
+    else {
+        qDebug() << "Decrypted aem failed to validate";
+    }
+
+    EVP_CIPHER_CTX_free(ctx);
+
+    return result;
+}

--- a/contracd/src/metadata.h
+++ b/contracd/src/metadata.h
@@ -1,0 +1,40 @@
+#ifndef METADATA_H
+#define METADATA_H
+
+#include <QObject>
+
+#define AEM_SIZE (4u)
+#define TX_POWER_UNKNOWN (0)
+
+class Metadata
+{
+public:
+    explicit Metadata();
+    explicit Metadata(QByteArray const &dtk, QByteArray const &rpi, qint8 txPower);
+    explicit Metadata(QByteArray const &aem);
+
+    void setDtk(QByteArray const &dtk);
+    void setRpi(QByteArray const &rpi);
+    void setTxPower(qint8 txPower);
+    void setEncryptedMetadata(QByteArray const &aem);
+
+    bool valid() const;
+    qint8 txPower();
+    QByteArray metadata();
+    QByteArray encryptedMetadata();
+
+private:
+    bool encryptMetadata();
+    bool decryptMetadata();
+
+public:
+    QByteArray m_dtk;
+    QByteArray m_rpi;
+    qint8 m_txPower;
+    QByteArray m_aem;
+    bool m_needsEncrypting;
+    bool m_needsDecrypting;
+    bool m_valid;
+};
+
+#endif // METADATA_H

--- a/contracd/src/rpidataitem.h
+++ b/contracd/src/rpidataitem.h
@@ -4,18 +4,20 @@
 #include <QObject>
 
 #include "contactinterval.h"
+#include "metadata.h"
 
-#define RPI_SERIALISE_SIZE (RPI_SIZE + sizeof(RpiDataItem::m_interval) + sizeof(RpiDataItem::m_rssi))
+#define RPI_SERIALISE_SIZE (RPI_SIZE + AEM_SIZE + sizeof(RpiDataItem::m_interval) + sizeof(RpiDataItem::m_rssi))
 
 class RpiDataItem
 {
 public:
     RpiDataItem();
-    RpiDataItem(ctinterval interval, qint16 rssi, QByteArray rpi);
+    RpiDataItem(ctinterval interval, qint16 rssi, QByteArray const &rpi, QByteArray const &aem);
 
     ctinterval m_interval = 0;
     qint16 m_rssi = 0;
     QByteArray m_rpi;
+    QByteArray m_aem;
 
     QByteArray serialise() const;
     bool deserialise(QByteArray const &data);

--- a/contracd/src/settings.cpp
+++ b/contracd/src/settings.cpp
@@ -11,6 +11,8 @@ Settings::Settings(QObject *parent) : QObject(parent),
     m_enabled = settings.value(QStringLiteral("state/enabled"), false).toBool();
     m_sent = settings.value(QStringLiteral("state/sent"), 0).toUInt();
     m_received = settings.value(QStringLiteral("state/received"), 0).toUInt();
+    m_txPower = static_cast<qint8>(settings.value(QStringLiteral("configuration/txPower"), -30).toInt());
+    m_rssiCorrection = static_cast<qint8>(settings.value(QStringLiteral("configuration/rssiCorretion"), 5).toInt());
 
     qDebug() << "Settings created: " << settings.fileName();
 }
@@ -21,7 +23,10 @@ Settings::~Settings()
     settings.setValue(QStringLiteral("state/enabled"), m_enabled);
     settings.setValue(QStringLiteral("state/sent"), m_sent);
     settings.setValue(QStringLiteral("state/received"), m_received);
+    settings.setValue(QStringLiteral("configuration/txPower"), m_txPower);
+    settings.setValue(QStringLiteral("configuration/rssiCorrection"), m_rssiCorrection);
 
+    instance = nullptr;
     qDebug() << "Deleted settings";
 }
 
@@ -88,5 +93,39 @@ void Settings::setReceived(quint32 received)
         m_received = received;
 
         emit receivedChanged();
+    }
+}
+
+qint8 Settings::txPower() const
+{
+    // The txPower is an empirically-determined device-specific value
+    // See https://developers.google.com/android/exposure-notifications/ble-attenuation-overview
+
+    return m_txPower;
+}
+
+void Settings::setTxPower(qint8 txPower)
+{
+    if (m_txPower != txPower) {
+        m_txPower = txPower;
+
+        emit txPowerChanged();
+    }
+}
+
+qint8 Settings::rssiCorrection() const
+{
+    // The rssiCorrection is an empirically-determined device-specific value
+    // See https://developers.google.com/android/exposure-notifications/ble-attenuation-overview
+
+    return m_rssiCorrection;
+}
+
+void Settings::setRssiCorrection(qint8 rssiCorrection)
+{
+    if (m_rssiCorrection != rssiCorrection) {
+        m_rssiCorrection = rssiCorrection;
+
+        emit rssiCorrectionChanged();
     }
 }

--- a/contracd/src/settings.h
+++ b/contracd/src/settings.h
@@ -13,6 +13,8 @@ class Settings : public QObject
     Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
     Q_PROPERTY(quint32 sent READ sent WRITE setSent NOTIFY sentChanged)
     Q_PROPERTY(quint32 received READ received WRITE setReceived NOTIFY receivedChanged)
+    Q_PROPERTY(qint8 txPower READ txPower WRITE setTxPower NOTIFY txPowerChanged)
+    Q_PROPERTY(qint8 rssiCorrection READ rssiCorrection WRITE setRssiCorrection NOTIFY rssiCorrectionChanged)
 
 public:
     explicit Settings(QObject *parent = nullptr);
@@ -25,18 +27,24 @@ public:
     Q_INVOKABLE bool enabled() const;
     Q_INVOKABLE quint32 sent() const;
     Q_INVOKABLE quint32 received() const;
+    Q_INVOKABLE qint8 txPower() const;
+    Q_INVOKABLE qint8 rssiCorrection() const;
 
 signals:
     void tracingKeyChanged();
     void enabledChanged();
     void sentChanged();
     void receivedChanged();
+    void txPowerChanged();
+    void rssiCorrectionChanged();
 
 public slots:
     void setTracingKey(QByteArray const &tracingKey);
     void setEnabled(bool enabled);
     void setSent(quint32 sent);
     void setReceived(quint32 received);
+    void setTxPower(qint8 txPower);
+    void setRssiCorrection(qint8 rssiCorrection);
 
 private:
     static Settings * instance;
@@ -46,6 +54,8 @@ private:
     bool m_enabled;
     quint32 m_sent;
     quint32 m_received;
+    qint8 m_txPower;
+    qint8 m_rssiCorrection;
 };
 
 #endif // CONTRACD_SETTINGS_H

--- a/tests/test_tracing.cpp
+++ b/tests/test_tracing.cpp
@@ -3,6 +3,8 @@
 #include "../contracd/src/contrac.h"
 #include "../contracd/src/contactstorage.h"
 #include "../contracd/src/bloomfilter.h"
+#include "../contracd/src/metadata.h"
+#include "../contracd/src/settings.h"
 #include "../contracd/src/exposurenotification.h"
 #include "../contracd/src/exposurenotification_p.h"
 #include "../contracd/src/exposureconfiguration.h"
@@ -62,12 +64,25 @@ quint32 countDataFiles()
 Test_Tracing::Test_Tracing(QObject *parent) : QObject(parent)
 {
     QCoreApplication::setOrganizationDomain("www.flypig.co.uk");
+    QCoreApplication::setOrganizationName("harbour-contrac");
     QCoreApplication::setApplicationName("harbour-contrac-tests");
+}
+
+void Test_Tracing::init()
+{
+    Settings::instantiate(this);
 }
 
 void Test_Tracing::cleanup()
 {
     ContactStorage::clearAllDataFiles();
+
+    Settings &settings = Settings::getInstance();
+    delete &settings;
+    QString folder = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+    qDebug() << "Removing folder" << folder;
+    QDir dir(folder);
+    dir.removeRecursively();
 }
 
 void Test_Tracing::testDtk()
@@ -93,7 +108,7 @@ void Test_Tracing::testDtk()
     // Check the Daily Tracing Keys are generated correctly
     // Should use the standard test vectors when they're available
 
-    time = QDateTime::fromMSecsSinceEpoch(0).addDays(12u);
+    time = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(12u);
     contrac->setTime(time);
     QCOMPARE(contrac->dayNumber(), 12u);
     dtk_base64 = contrac->dtk();
@@ -101,7 +116,7 @@ void Test_Tracing::testDtk()
     dtk_base64 = dtk_base64.toBase64();
     QCOMPARE(dtk_base64, QByteArray("AzZ389DsGecAjZqby1sLNQ=="));
 
-    time = QDateTime::fromMSecsSinceEpoch(0).addDays(0u);
+    time = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(0u);
     contrac->setTime(time);
     QCOMPARE(contrac->dayNumber(), 0u);
     dtk_base64 = contrac->dtk();
@@ -109,7 +124,7 @@ void Test_Tracing::testDtk()
     dtk_base64 = dtk_base64.toBase64();
     QCOMPARE(dtk_base64, QByteArray("p7LrsTReTw3k721eIWDjRw=="));
 
-    time = QDateTime::fromMSecsSinceEpoch(0).addDays(143u);
+    time = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(143u);
     contrac->setTime(time);
     QCOMPARE(contrac->dayNumber(), 143u);
     dtk_base64 = contrac->dtk();
@@ -142,7 +157,7 @@ void Test_Tracing::testRpi()
     QCOMPARE(static_cast<unsigned int>(tk.length()), TK_SIZE);
     contrac->setTk(tk);
 
-    dayStart = QDateTime::fromMSecsSinceEpoch(0).addDays(9);
+    dayStart = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(9);
     contrac->setTime(dayStart);
     QCOMPARE(contrac->dayNumber(), static_cast<quint32>(9));
 
@@ -177,7 +192,7 @@ void Test_Tracing::testRpi()
     QCOMPARE(static_cast<unsigned int>(tk.length()), TK_SIZE);
     contrac->setTk(tk);
 
-    dayStart = QDateTime::fromMSecsSinceEpoch(0).addDays(500);
+    dayStart = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(500);
     contrac->setTime(dayStart);
     QCOMPARE(contrac->dayNumber(), static_cast<quint32>(500));
 
@@ -209,13 +224,271 @@ void Test_Tracing::testRpi()
     delete contrac;
 }
 
+void Test_Tracing::testMetadata()
+{
+    Contrac * contrac;
+    QDateTime time;
+    QByteArray dtk;
+    QByteArray rpi;
+    QByteArray content[2];
+    QByteArray aem[2];
+    QByteArray decrypted;
+    Metadata metadata[2];
+
+    contrac = new Contrac(this);
+    time = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(12u);
+    contrac->setTime(time);
+    QCOMPARE(contrac->dayNumber(), 12u);
+    dtk = contrac->dtk();
+    QCOMPARE(static_cast<unsigned int>(dtk.length()), DTK_SIZE);
+
+    rpi = contrac->rpi();
+    metadata[0].setDtk(dtk);
+    metadata[0].setRpi(rpi);
+    metadata[0].setTxPower(-35);
+
+    content[0] = metadata[0].metadata();
+    QCOMPARE(content[0].size(), 4);
+    QCOMPARE(content[0].at(0), char(0b01000000));
+    QCOMPARE(static_cast<qint8>(content[0].at(1)), qint8(-35));
+    QCOMPARE(content[0].at(2), char(0));
+    QCOMPARE(content[0].at(3), char(0));
+
+    aem[0] = metadata[0].encryptedMetadata();
+
+    QCOMPARE(static_cast<unsigned int>(aem[0].length()), AEM_SIZE);
+    QVERIFY(aem[0] != content);
+
+    metadata[1].setDtk(dtk);
+    metadata[1].setRpi(rpi);
+    metadata[1].setEncryptedMetadata(aem[0]);
+
+    decrypted = metadata[1].metadata();
+    QCOMPARE(decrypted.size(), 4);
+    QCOMPARE(content[0], decrypted);
+
+    time = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(165u);
+    contrac->setTime(time);
+    QCOMPARE(contrac->dayNumber(), 165u);
+    dtk = contrac->dtk();
+    QCOMPARE(static_cast<unsigned int>(dtk.length()), DTK_SIZE);
+
+    rpi = contrac->rpi();
+    metadata[0].setDtk(dtk);
+    metadata[0].setRpi(rpi);
+    metadata[0].setTxPower(127);
+
+    content[1] = metadata[0].metadata();
+
+    QVERIFY(content[0] != content[1]);
+
+    QCOMPARE(content[1].size(), 4);
+    QCOMPARE(content[1].at(0), char(0b01000000));
+    QCOMPARE(static_cast<qint8>(content[1].at(1)), qint8(127));
+    QCOMPARE(content[1].at(2), char(0));
+    QCOMPARE(content[1].at(3), char(0));
+
+    aem[1] = metadata[0].encryptedMetadata();
+
+    QVERIFY(aem[0] != aem[1]);
+
+    QCOMPARE(static_cast<unsigned int>(aem[1].length()), AEM_SIZE);
+    QVERIFY(aem[1] != content);
+
+    metadata[1].setDtk(dtk);
+    metadata[1].setRpi(rpi);
+    metadata[1].setEncryptedMetadata(aem[1]);
+
+    decrypted = metadata[1].metadata();
+    QCOMPARE(decrypted.size(), 4);
+    QCOMPARE(content[1], decrypted);
+
+    // Clean up
+    delete contrac;
+}
+
+void Test_Tracing::testMatchAggregation()
+{
+    QByteArray const tracing_key_base64("p4QrDr0/C1D5ejQDN9tWnZdhRiKijGc9VeBlro8JfIQ=");
+    QList<QPair<QByteArray, quint32>> diagnosis_list;
+    // There are six matches in amongst this lot
+    // (day, time) = (1170, 4500), (1175, 20100), (1175, 42600), (1170, 27850), (1170, 27500), (1170, 27600)
+    quint32 beacon_days[11] = {1174 - DAYS_TO_STORE, 1171, 1170, 1172, 1173, 1175, 1175, 1174, 1170, 1170, 1170};
+    // These beacon_times are measured in 2 second intervals (ctinterval)
+    ctinterval beacon_times[11] = {9900, 300, 4500, 1500, 30300, 20100, 42600, 15300, 27850, 27500, 27600};
+    qint8 beacon_invalidate[11] = {-1, -1, -1, -1, -1, 2, 3, -1, -1, -1, -1};
+    qint8 beacon_txPower[11] = {-31, -31, -31, -100, -31, -100, -31, -31, -31, -31, -31};
+    qint8 beacon_rssi[11] = {-64, -64, -64, -64, -64, -64, -64, -64, -38, -64, -127};
+    // Note that the first diagnosis day will be dropped as out of range
+    quint32 diagnosis_days[3] = {1174 - DAYS_TO_STORE, 1170, 1175};
+    QMap<quint32, QList<ctinterval>> expectedMatches;
+    int pos;
+    QByteArray rpi_bytes;
+    QByteArray dtk_bytes;
+    QList<ContactMatch> matches;
+    Metadata metadata;
+    QByteArray aem;
+    QList<ExposureInformation> exposureInfoList;
+    ExposureConfiguration configuration;
+
+    ContactStorage::clearAllDataFiles();
+
+    // Set up the configuration
+    configuration.setMinimumRiskScore(0);
+    configuration.setAttenuationScores(QList<quint32>({0, 1, 2, 3, 4, 5, 6, 7}));
+    configuration.setDaysSinceLastExposureScores(QList<quint32>({0, 1, 2, 3, 4, 5, 6, 7}));
+    configuration.setDurationScores(QList<quint32>({0, 1, 2, 3, 4, 5, 6, 7}));
+    configuration.setTransmissionRiskScores(QList<quint32>({0, 1, 2, 3, 4, 5, 6, 7}));
+    configuration.setAttenuationWeight(1.0);
+    configuration.setDaysSinceLastExposureWeight(1.0);
+    configuration.setDurationWeight(1.0);
+    configuration.setTransmissionRiskWeight(1.0);
+    configuration.setDurationAtAttenuationThresholds(QList<qint32>({8, 64}));
+
+    // Generate some keys, check the results
+    Contrac * contrac;
+    ContactStorage * storage;
+
+    contrac = new Contrac(this);
+    QVERIFY(contrac != nullptr);
+
+    storage = new ContactStorage(contrac);
+    QVERIFY(storage != nullptr);
+
+    contrac->setTk(QByteArray::fromBase64(tracing_key_base64));
+
+    // Generate some beacons (as if collected over BlueTooth)
+    for (pos = 0; pos < 11; ++pos) {
+        QDateTime time = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(beacon_days[pos]).addSecs((CTINTERVAL_DURATION / 1000) * beacon_times[pos]);
+        contrac->setTime(time);
+        QCOMPARE(contrac->dayNumber(), static_cast<quint32>(beacon_days[pos]));
+        QCOMPARE(contrac->timeIntervalNumber(), ctIntervalToInterval(beacon_times[pos]));
+
+        dtk_bytes = contrac->dtk();
+        rpi_bytes = contrac->rpi();
+
+        metadata.setDtk(dtk_bytes);
+        metadata.setRpi(rpi_bytes);
+        metadata.setTxPower(beacon_txPower[pos]);
+        aem = metadata.encryptedMetadata();
+        QVERIFY(metadata.valid());
+        if ((beacon_invalidate[pos] >= 0) && (beacon_invalidate[pos] < int(AEM_SIZE))) {
+            aem[beacon_invalidate[pos]] = aem.at(beacon_invalidate[pos]) ^ char(0b00000001);
+        }
+
+        storage->addContact(beacon_times[pos], rpi_bytes, aem, beacon_rssi[pos]);
+    }
+
+    // Generate some diagnosis data (as if provided by a diagnosis server)
+    for (pos = 0; pos < 3; ++pos) {
+        QDateTime time = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(diagnosis_days[pos]).addSecs(60 * 10 * 50);
+        contrac->setTime(time);
+        QCOMPARE(contrac->dayNumber(), static_cast<quint32>(diagnosis_days[pos]));
+        QCOMPARE(contrac->timeIntervalNumber(), static_cast<quint8>(50));
+
+        dtk_bytes = contrac->dtk();
+        diagnosis_list.append(QPair<QByteArray, quint32>(dtk_bytes, diagnosis_days[pos]));
+    }
+
+    // Verify the results; they should look like this
+    // Exposure Info, day: 1170
+    //    dateMillisSinceEpoch: 2303752192
+    //    durationMinutes: 5
+    //    attenuationValue: 28
+    //    transmissionRiskLevel: 4
+    //    totalRiskScore: 112
+    //    attenuationDurations: (0, 1, 0)
+    //
+    //    dateMillisSinceEpoch: 2303752192
+    //    durationMinutes: 15
+    //    attenuationValue: 29
+    //    transmissionRiskLevel: 4
+    //    totalRiskScore: 336
+    //    attenuationDurations: (9, 1, 4)
+    //
+    // Exposure Info, day: 1175
+    // Note these should be empty due to failed validation
+    //    dateMillisSinceEpoch: 2735752192
+    //    durationMinutes: 0
+    //    attenuationValue: 0
+    //    transmissionRiskLevel: 4
+    //    totalRiskScore: 0
+    //    attenuationDurations: (0, 0, 0)
+    //
+    //    dateMillisSinceEpoch: 2735752192
+    //    durationMinutes: 0
+    //    attenuationValue: 0
+    //    transmissionRiskLevel: 4
+    //    totalRiskScore: 0
+    //    attenuationDurations: (0, 0, 0)
+
+    // Set up the expected matches
+    expectedMatches.insert(1170, {4500, 27850, 27500, 27600});
+    expectedMatches.insert(1175, {20100, 42600});
+    struct AggregateMatch {
+        quint64 dateMillisSinceEpoch;
+        qint32 durationMinutes;
+        qint32 attenuationValue;
+        qint32 transmissionRiskLevel;
+        qint32 totalRiskScore;
+        QList<qint32> attenuationDurations;
+    };
+    QList<AggregateMatch> aggregateMatches;
+    aggregateMatches += {2303752192, 5, 28, 4, 112, {0, 1, 0}};
+    aggregateMatches += {2303752192, 15, 29, 4, 336, {9, 1, 4}};
+    aggregateMatches += {2735752192, 0, 0, 4, 0, {0, 0, 0}};
+    aggregateMatches += {2735752192, 0, 0, 4, 0, {0, 0, 0}};
+
+    int total_matches = 0;
+    // Check that the matching algorithm identifies the beacons that match
+    for (QPair<QByteArray, quint32> diagnosis : diagnosis_list) {
+        QList<DiagnosisKey> dtks;
+        dtks.append(DiagnosisKey(diagnosis.first, DiagnosisKey::RiskLevelMedium, diagnosis.second * 144, 144));
+        matches = storage->findDtkMatches(diagnosis.second, dtks);
+        QCOMPARE((matches.length() > 0), expectedMatches.contains(diagnosis.second));
+        for (ContactMatch match : matches) {
+            total_matches += match.m_rpis.length();
+
+            QList<ctinterval> intervals = expectedMatches[diagnosis.second];
+            for (RpiDataItem rpi : match.m_rpis) {
+                QVERIFY(intervals.contains(rpi.m_interval));
+                intervals.removeOne(rpi.m_interval);
+                expectedMatches[diagnosis.second] = intervals;
+            }
+        }
+
+        exposureInfoList = ExposureNotificationPrivate::aggregateExposureData(diagnosis.second, configuration, matches, 0);
+        for (ExposureInformation exposureInfo : exposureInfoList) {
+            bool match = false;
+            int checkPos;
+            for (checkPos = 0; !match && checkPos < aggregateMatches.length(); ++checkPos) {
+                AggregateMatch check = aggregateMatches[checkPos];
+                if ((check.dateMillisSinceEpoch == exposureInfo.dateMillisSinceEpoch()) && (check.durationMinutes == exposureInfo.durationMinutes()) && check.attenuationValue == exposureInfo.attenuationValue() && check.transmissionRiskLevel == exposureInfo.transmissionRiskLevel() && check.totalRiskScore == exposureInfo.totalRiskScore() && check.attenuationDurations == exposureInfo.attenuationDurations()) {
+                    match = true;
+                    aggregateMatches.removeAt(checkPos);
+                }
+            }
+            QVERIFY(match);
+        }
+    }
+
+    QCOMPARE(total_matches, 6);
+    QCOMPARE(aggregateMatches.length(), 0);
+
+    // Clean up
+    delete storage;
+    delete contrac;
+
+    ContactStorage::clearAllDataFiles();
+}
+
 void Test_Tracing::testBloomFilter()
 {
     BloomFilter bloomfilter(100, 32768, 11);
     Contrac contrac;
     int count;
 
-    QDateTime date = QDateTime::fromMSecsSinceEpoch(qint64(1589228731) * qint64(1000));
+    QDateTime date = QDateTime::fromMSecsSinceEpoch(qint64(1589228731) * qint64(1000), Qt::UTC);
 
     QByteArrayList included;
     QByteArrayList excluded;
@@ -257,8 +530,11 @@ void Test_Tracing::testBloomFilter()
 void Test_Tracing::testStorage()
 {
     quint32 day;
+    QByteArray dtk_bytes;
     QByteArray rpi_bytes;
     QDateTime time;
+    Metadata metadata;
+    QByteArray aem;
 
     ContactStorage::clearAllDataFiles();
     QCOMPARE(countDataFiles(), 0u);
@@ -270,7 +546,7 @@ void Test_Tracing::testStorage()
     contrac = new Contrac(this);
     QVERIFY(contrac != nullptr);
 
-    time = QDateTime::fromMSecsSinceEpoch(0).addDays(176).addSecs(60 * 10 * 5);
+    time = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(176).addSecs(60 * 10 * 5);
     contrac->setTime(time);
 
     storage = new ContactStorage(contrac);
@@ -278,13 +554,21 @@ void Test_Tracing::testStorage()
 
     // First ten files
     for (day = 176; day < 176 + 10; ++day) {
-        time = QDateTime::fromMSecsSinceEpoch(0).addDays(day).addSecs(60 * 10 * 5);
+        time = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(day).addSecs(60 * 10 * 5);
         contrac->setTime(time);
         QCOMPARE(contrac->dayNumber(), static_cast<quint32>(day));
         QCOMPARE(contrac->timeIntervalNumber(), static_cast<quint8>(5));
 
+        dtk_bytes = contrac->dtk();
         rpi_bytes = contrac->rpi();
-        storage->addContact(5, rpi_bytes, -64);
+
+        metadata.setDtk(dtk_bytes);
+        metadata.setRpi(rpi_bytes);
+        metadata.setTxPower(-25);
+        aem = metadata.encryptedMetadata();
+        QVERIFY(metadata.valid());
+
+        storage->addContact(5, rpi_bytes, aem, -64);
     }
 
     delete storage;
@@ -298,13 +582,21 @@ void Test_Tracing::testStorage()
 
     // Next 8 files
     for (day = 176 + 11; day < 176 + 18; ++day) {
-        time = QDateTime::fromMSecsSinceEpoch(0).addDays(day).addSecs(60 * 10 * 5);
+        time = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(day).addSecs(60 * 10 * 5);
         contrac->setTime(time);
         QCOMPARE(contrac->dayNumber(), static_cast<quint32>(day));
         QCOMPARE(contrac->timeIntervalNumber(), static_cast<quint8>(5));
 
+        dtk_bytes = contrac->dtk();
         rpi_bytes = contrac->rpi();
-        storage->addContact(5, rpi_bytes, -64);
+
+        metadata.setDtk(dtk_bytes);
+        metadata.setRpi(rpi_bytes);
+        metadata.setTxPower(-25);
+        aem = metadata.encryptedMetadata();
+        QVERIFY(metadata.valid());
+
+        storage->addContact(5, rpi_bytes, aem, -64);
     }
 
     delete storage;
@@ -332,21 +624,27 @@ void Test_Tracing::testStorage()
 void Test_Tracing::testMatch()
 {
     QByteArray const tracing_key_base64("3UmKrtcQ2tfLE8UPSXHb4PtgRfE0E2xdSs+PGVIS8cc=");
-    QList<QPair<QByteArray, quint8>> beacon_list;
     QList<QPair<QByteArray, quint32>> diagnosis_list;
     // There are four matches in amongst this lot
-    // (day, time) = (12, 15), (1175, 142), (1175, 67), (12, 93)
+    // (day, time) = (1170, 15), (1175, 142), (1175, 67), (1170, 93)
     quint32 beacon_days[9] = {1174 - DAYS_TO_STORE, 1171, 1170, 1172, 1173, 1175, 1175, 1174, 1170};
-    quint8 beacon_times[9] = {33, 1, 15, 5, 101, 142, 67, 51, 93};
+    quint8 beacon_times[9] = {33, 1, 15, 5, 101, 67, 142, 51, 93};
     // Note that the first diagnosis day will be dropped as out of range
     quint32 diagnosis_days[3] = {1174 - DAYS_TO_STORE, 1170, 1175};
     // Summarise the four matches
     QList<quint32> match_days({1170, 1175, 1175, 1170});
-    QList<quint8> match_times({15, 142, 67, 93});
+    QList<quint8> match_times({15, 67, 142, 93});
     int pos;
     QByteArray rpi_bytes;
     QByteArray dtk_bytes;
     QList<ContactMatch> matches;
+    Metadata metadata;
+    QByteArray aem;
+
+    // The expected matches
+    QMap<quint32, QList<quint8>> expectecMatches;
+    expectecMatches.insert(1170, {15, 93});
+    expectecMatches.insert(1175, {67, 142});
 
     ContactStorage::clearAllDataFiles();
 
@@ -364,21 +662,27 @@ void Test_Tracing::testMatch()
 
     // Generate some beacons (as if collected over BlueTooth)
     for (pos = 0; pos < 9; ++pos) {
-        QDateTime time = QDateTime::fromMSecsSinceEpoch(0).addDays(beacon_days[pos]).addSecs(60 * 10 * beacon_times[pos]);
+        QDateTime time = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(beacon_days[pos]).addSecs(60 * 10 * beacon_times[pos]);
         contrac->setTime(time);
         QCOMPARE(contrac->dayNumber(), static_cast<quint32>(beacon_days[pos]));
         QCOMPARE(contrac->timeIntervalNumber(), static_cast<quint8>(beacon_times[pos]));
 
+        dtk_bytes = contrac->dtk();
         rpi_bytes = contrac->rpi();
-        beacon_list.append(QPair<QByteArray, quint8>(rpi_bytes, beacon_times[pos]));
+
+        metadata.setDtk(dtk_bytes);
+        metadata.setRpi(rpi_bytes);
+        metadata.setTxPower(-31);
+        aem = metadata.encryptedMetadata();
+        QVERIFY(metadata.valid());
 
         ctinterval interval = intervalToCtInterval(beacon_times[pos]);
-        storage->addContact(interval, rpi_bytes, -64);
+        storage->addContact(interval, rpi_bytes, aem, -64);
     }
 
     // Generate some diagnosis data (as if provided by a diagnosis server)
     for (pos = 0; pos < 3; ++pos) {
-        QDateTime time = QDateTime::fromMSecsSinceEpoch(0).addDays(diagnosis_days[pos]).addSecs(60 * 10 * 50);
+        QDateTime time = QDateTime::fromMSecsSinceEpoch(0, Qt::UTC).addDays(diagnosis_days[pos]).addSecs(60 * 10 * 50);
         contrac->setTime(time);
         QCOMPARE(contrac->dayNumber(), static_cast<quint32>(diagnosis_days[pos]));
         QCOMPARE(contrac->timeIntervalNumber(), static_cast<quint8>(50));
@@ -388,12 +692,25 @@ void Test_Tracing::testMatch()
     }
 
     // Check that the matching algorithm identifies the beacons that match
+    int total_matches = 0;
     for (QPair<QByteArray, quint32> diagnosis : diagnosis_list) {
         QList<DiagnosisKey> dtks;
-        dtks.append(DiagnosisKey(diagnosis.first, 0, 50, 1));
+        dtks.append(DiagnosisKey(diagnosis.first, DiagnosisKey::RiskLevelMedium, diagnosis.second * 144, 144));
         matches = storage->findDtkMatches(diagnosis.second, dtks);
-        QCOMPARE((matches.length() > 0), match_days.contains(diagnosis.second));
+
+        for (ContactMatch match : matches) {
+            QList<quint8> timeMatches = expectecMatches[diagnosis.second];
+            for (RpiDataItem rpi : match.m_rpis) {
+                ++total_matches;
+                QVERIFY(timeMatches.contains(ctIntervalToInterval(rpi.m_interval)));
+                if (timeMatches.contains(ctIntervalToInterval(rpi.m_interval))) {
+                    timeMatches.removeOne(ctIntervalToInterval(rpi.m_interval));
+                    expectecMatches[diagnosis.second] = timeMatches;
+                }
+            }
+        }
     }
+    QCOMPARE(total_matches, 4);
 
     // Clean up
     delete storage;

--- a/tests/test_tracing.h
+++ b/tests/test_tracing.h
@@ -10,10 +10,13 @@ public:
     explicit Test_Tracing(QObject *parent = nullptr);
 
 private slots:
+    void init();
     void cleanup();
 
     void testDtk();
     void testRpi();
+    void testMetadata();
+    void testMatchAggregation();
     void testBloomFilter();
     void testStorage();
     void testMatch();

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -42,7 +42,7 @@ HEADERS += \
     ../contracd/proto/contrac.pb.h \
     ../contracd/src/bleadvertisement.h \
     ../contracd/src/bleadvertisementmanager.h \
-    ../contracd/src/bleascanner.h \
+    ../contracd/src/blescanner.h \
     ../contracd/src/bloomfilter.h \
     ../contracd/src/contactinterval.h \
     ../contracd/src/contactmatch.h \
@@ -61,7 +61,8 @@ HEADERS += \
     ../contracd/src/rpidataitem.h \
     ../contracd/src/settings.h \
     ../contracd/src/temporaryexposurekey.h \
-    ../contracd/src/zipistreambuffer.h
+    ../contracd/src/zipistreambuffer.h \
+    ../contracd/src/metadata.h
 
 SOURCES += \
     ../src/contactmodel.cpp \
@@ -86,7 +87,8 @@ SOURCES += \
     ../contracd/src/rpidataitem.cpp \
     ../contracd/src/settings.cpp \
     ../contracd/src/temporaryexposurekey.cpp \
-    ../contracd/src/zipistreambuffer.cpp
+    ../contracd/src/zipistreambuffer.cpp \
+    ../contracd/src/metadata.cpp
 
 INCLUDEPATH += $$OUT_PWD/../contracd/proto
 


### PR DESCRIPTION
Adds four bytes of encrypted metadata to the advertising beacons. The
data can only be decrypted if the tracing key is known.

Fixes issue #25.