### PR TITLE
Download config from server and perform analysis

### DIFF
--- a/contrac.pro
+++ b/contrac.pro
@@ -20,24 +20,34 @@ DEFINES += "VERSION_MAJOR=$$VERSION_MAJOR" \
     "VERSION=\\\"$$VERSION\\\""
 
 #protobuf build step
-PRE_TARGETDEPS += proto/submissionpayload.pb.cc
-protobuf.target = proto/submissionpayload.pb.cc
-protobuf.path = $$OUT_PWD
-protobuf.commands = \
+PRE_TARGETDEPS += proto/submissionpayload.pb.cc \
+    proto/applicationConfiguration.pb.cc
+
+submissionpayload.target = proto/submissionpayload.pb.cc
+submissionpayload.path = $$OUT_PWD
+submissionpayload.commands = \
     mkdir -p $$OUT_PWD/proto; \
     protoc --proto_path=$$PWD/src --cpp_out=$$OUT_PWD/proto $$PWD/src/submissionpayload.proto
 
+applicationconfig.target = proto/applicationConfiguration.pb.cc
+applicationconfig.path = $$OUT_PWD
+applicationconfig.commands = \
+    mkdir -p $$OUT_PWD/proto; \
+    protoc --proto_path=$$PWD/src --cpp_out=$$OUT_PWD/proto $$PWD/src/applicationConfiguration.proto
+
 INCLUDEPATH += $$OUT_PWD/proto
 
-QMAKE_EXTRA_TARGETS += protobuf
+QMAKE_EXTRA_TARGETS += submissionpayload applicationconfig
 
 CONFIG += sailfishapp
 
 HEADERS += \
     proto/submissionpayload.pb.h \
+    proto/applicationConfiguration.pb.h \
     src/dbusproxy.h \
     src/contactmodel.h \
     src/download.h \
+    src/downloadconfig.h \
     src/s3access.h \
     src/s3/s3.h \
     src/s3/s3internal.h \
@@ -46,11 +56,14 @@ HEADERS += \
     contracd/src/exposureinformation.h \
     contracd/src/temporaryexposurekey.h \
     contracd/src/exposureconfiguration.h \
+    contracd/src/zipistreambuffer.h \
     src/settings.h \
     src/upload.h
 
 SOURCES += \
     proto/submissionpayload.pb.cc \
+    proto/applicationConfiguration.pb.cc \
+    src/downloadconfig.cpp \
     src/harbour-contrac.cpp \
     src/dbusproxy.cpp \
     src/contactmodel.cpp \
@@ -65,6 +78,7 @@ SOURCES += \
     contracd/src/exposureinformation.cpp \
     contracd/src/temporaryexposurekey.cpp \
     contracd/src/exposureconfiguration.cpp \
+    contracd/src/zipistreambuffer.cpp \
     src/settings.cpp \
     src/upload.cpp
 
@@ -80,6 +94,7 @@ DISTFILES += \
     qml/components/Dash.qml \
     qml/components/InfoRow.qml \
     qml/components/TanChar.qml \
+    src/applicationConfiguration.proto \
     translations/*.ts
 
 SAILFISHAPP_ICONS = 86x86 108x108 128x128 172x172 256x256
@@ -103,6 +118,7 @@ PKGCONFIG += \
     libxml-2.0 \
     libcurl \
     protobuf-lite \
+    quazip
 
 DEFINES += LINUX
 

--- a/contracd/src/exposureconfiguration.cpp
+++ b/contracd/src/exposureconfiguration.cpp
@@ -70,21 +70,24 @@ QDBusArgument &operator<<(QDBusArgument &argument, const ExposureConfiguration &
 QDBusArgument const &operator>>(const QDBusArgument &argument, ExposureConfiguration &exposureConfiguration)
 {
     quint8 valueInt8;
-    QList<quint32> valueUnsignedList;
     double valueDouble;
     QList<qint32> valueSignedList;
 
     argument.beginStructure();
     argument >> valueInt8;
     exposureConfiguration.setMinimumRiskScore(valueInt8);
-    argument >> valueUnsignedList;
-    exposureConfiguration.setAttenuationScores(valueUnsignedList);
-    argument >> valueUnsignedList;
-    exposureConfiguration.setDaysSinceLastExposureScores(valueUnsignedList);
-    argument >> valueUnsignedList;
-    exposureConfiguration.setDurationScores(valueUnsignedList);
-    argument >> valueUnsignedList;
-    exposureConfiguration.setTransmissionRiskScores(valueUnsignedList);
+    valueSignedList.clear();
+    argument >> valueSignedList;
+    exposureConfiguration.setAttenuationScores(valueSignedList);
+    valueSignedList.clear();
+    argument >> valueSignedList;
+    exposureConfiguration.setDaysSinceLastExposureScores(valueSignedList);
+    valueSignedList.clear();
+    argument >> valueSignedList;
+    exposureConfiguration.setDurationScores(valueSignedList);
+    valueSignedList.clear();
+    argument >> valueSignedList;
+    exposureConfiguration.setTransmissionRiskScores(valueSignedList);
     argument >> valueDouble;
     exposureConfiguration.setAttenuationWeight(valueDouble);
     argument >> valueDouble;
@@ -93,6 +96,7 @@ QDBusArgument const &operator>>(const QDBusArgument &argument, ExposureConfigura
     exposureConfiguration.setDurationWeight(valueDouble);
     argument >> valueDouble;
     exposureConfiguration.setTransmissionRiskWeight(valueDouble);
+    valueSignedList.clear();
     argument >> valueSignedList;
     exposureConfiguration.setDurationAtAttenuationThresholds(valueSignedList);
     argument.endStructure();
@@ -100,27 +104,27 @@ QDBusArgument const &operator>>(const QDBusArgument &argument, ExposureConfigura
     return argument;
 }
 
-quint8 ExposureConfiguration::minimumRiskScore() const
+qint32 ExposureConfiguration::minimumRiskScore() const
 {
     return m_minimumRiskScore;
 }
 
-QList<quint32> ExposureConfiguration::attenuationScores() const
+QList<qint32> ExposureConfiguration::attenuationScores() const
 {
     return m_attenuationScores;
 }
 
-QList<quint32> ExposureConfiguration::daysSinceLastExposureScores() const
+QList<qint32> ExposureConfiguration::daysSinceLastExposureScores() const
 {
     return m_daysSinceLastExposureScores;
 }
 
-QList<quint32> ExposureConfiguration::durationScores() const
+QList<qint32> ExposureConfiguration::durationScores() const
 {
     return m_durationScores;
 }
 
-QList<quint32> ExposureConfiguration::transmissionRiskScores() const
+QList<qint32> ExposureConfiguration::transmissionRiskScores() const
 {
     return m_transmissionRiskScores;
 }
@@ -150,7 +154,7 @@ QList<qint32> ExposureConfiguration::durationAtAttenuationThresholds() const
     return m_durationAtAttenuationThresholds;
 }
 
-void ExposureConfiguration::setMinimumRiskScore(quint8 minimumRiskScore)
+void ExposureConfiguration::setMinimumRiskScore(qint32 minimumRiskScore)
 {
     if (m_minimumRiskScore != minimumRiskScore) {
         m_minimumRiskScore = minimumRiskScore;
@@ -158,7 +162,7 @@ void ExposureConfiguration::setMinimumRiskScore(quint8 minimumRiskScore)
     }
 }
 
-void ExposureConfiguration::setAttenuationScores(QList<quint32> attenuationScores)
+void ExposureConfiguration::setAttenuationScores(QList<qint32> attenuationScores)
 {
     if (m_attenuationScores != attenuationScores) {
         m_attenuationScores = attenuationScores;
@@ -166,7 +170,7 @@ void ExposureConfiguration::setAttenuationScores(QList<quint32> attenuationScore
     }
 }
 
-void ExposureConfiguration::setDaysSinceLastExposureScores(QList<quint32> daysSinceLastExposureScores)
+void ExposureConfiguration::setDaysSinceLastExposureScores(QList<qint32> daysSinceLastExposureScores)
 {
     if (m_daysSinceLastExposureScores != daysSinceLastExposureScores) {
         m_daysSinceLastExposureScores = daysSinceLastExposureScores;
@@ -174,7 +178,7 @@ void ExposureConfiguration::setDaysSinceLastExposureScores(QList<quint32> daysSi
     }
 }
 
-void ExposureConfiguration::setDurationScores(QList<quint32> durationScores)
+void ExposureConfiguration::setDurationScores(QList<qint32> durationScores)
 {
     if (m_durationScores != durationScores) {
         m_durationScores = durationScores;
@@ -182,7 +186,7 @@ void ExposureConfiguration::setDurationScores(QList<quint32> durationScores)
     }
 }
 
-void ExposureConfiguration::setTransmissionRiskScores(QList<quint32> transmissionRiskScores)
+void ExposureConfiguration::setTransmissionRiskScores(QList<qint32> transmissionRiskScores)
 {
     if (m_transmissionRiskScores != transmissionRiskScores) {
         m_transmissionRiskScores = transmissionRiskScores;

--- a/contracd/src/exposureconfiguration.cpp
+++ b/contracd/src/exposureconfiguration.cpp
@@ -1,6 +1,5 @@
 #include "exposureconfiguration.h"
 
-
 ExposureConfiguration::ExposureConfiguration(QObject *parent)
     : QObject(parent)
     , m_minimumRiskScore(0)

--- a/contracd/src/exposureconfiguration.h
+++ b/contracd/src/exposureconfiguration.h
@@ -8,11 +8,11 @@ class ExposureConfiguration : public QObject
 {
     Q_OBJECT
 
-    Q_PROPERTY(quint8 minimumRiskScore READ minimumRiskScore WRITE setMinimumRiskScore NOTIFY minimumRiskScoreChanged)
-    Q_PROPERTY(QList<quint32> attenuationScores READ attenuationScores WRITE setAttenuationScores NOTIFY attenuationScoresChanged)
-    Q_PROPERTY(QList<quint32> daysSinceLastExposureScores READ daysSinceLastExposureScores WRITE setDaysSinceLastExposureScores NOTIFY daysSinceLastExposureScoresChanged)
-    Q_PROPERTY(QList<quint32> durationScores READ durationScores WRITE setDurationScores NOTIFY durationScoresChanged)
-    Q_PROPERTY(QList<quint32> transmissionRiskScores READ transmissionRiskScores WRITE setTransmissionRiskScores NOTIFY transmissionRiskScoresChanged)
+    Q_PROPERTY(qint32 minimumRiskScore READ minimumRiskScore WRITE setMinimumRiskScore NOTIFY minimumRiskScoreChanged)
+    Q_PROPERTY(QList<qint32> attenuationScores READ attenuationScores WRITE setAttenuationScores NOTIFY attenuationScoresChanged)
+    Q_PROPERTY(QList<qint32> daysSinceLastExposureScores READ daysSinceLastExposureScores WRITE setDaysSinceLastExposureScores NOTIFY daysSinceLastExposureScoresChanged)
+    Q_PROPERTY(QList<qint32> durationScores READ durationScores WRITE setDurationScores NOTIFY durationScoresChanged)
+    Q_PROPERTY(QList<qint32> transmissionRiskScores READ transmissionRiskScores WRITE setTransmissionRiskScores NOTIFY transmissionRiskScoresChanged)
 
     Q_PROPERTY(double attenuationWeight READ attenuationWeight WRITE setAttenuationWeight NOTIFY attenuationWeightChanged)
     Q_PROPERTY(double daysSinceLastExposureWeight READ daysSinceLastExposureWeight WRITE setDaysSinceLastExposureWeight NOTIFY daysSinceLastExposureWeightChanged)
@@ -25,22 +25,22 @@ public:
     ExposureConfiguration(ExposureConfiguration const &exposureConfiguration);
     ExposureConfiguration& operator=( const ExposureConfiguration &other);
 
-    quint8 minimumRiskScore() const;
-    QList<quint32> attenuationScores() const;
-    QList<quint32> daysSinceLastExposureScores() const;
-    QList<quint32> durationScores() const;
-    QList<quint32> transmissionRiskScores() const;
+    qint32 minimumRiskScore() const;
+    QList<qint32> attenuationScores() const;
+    QList<qint32> daysSinceLastExposureScores() const;
+    QList<qint32> durationScores() const;
+    QList<qint32> transmissionRiskScores() const;
     double attenuationWeight() const;
     double daysSinceLastExposureWeight() const;
     double durationWeight() const;
     double transmissionRiskWeight() const;
     QList<qint32> durationAtAttenuationThresholds() const;
 
-    void setMinimumRiskScore(quint8 minimumRiskScore);
-    void setAttenuationScores(QList<quint32> attenuationScores);
-    void setDaysSinceLastExposureScores(QList<quint32> daysSinceLastExposureScores);
-    void setDurationScores(QList<quint32> durationScores);
-    void setTransmissionRiskScores(QList<quint32> transmissionRiskScores);
+    void setMinimumRiskScore(qint32 minimumRiskScore);
+    void setAttenuationScores(QList<qint32> attenuationScores);
+    void setDaysSinceLastExposureScores(QList<qint32> daysSinceLastExposureScores);
+    void setDurationScores(QList<qint32> durationScores);
+    void setTransmissionRiskScores(QList<qint32> transmissionRiskScores);
     void setAttenuationWeight(double attenuationWeight);
     void setDaysSinceLastExposureWeight(double daysSinceLastExposureWeight);
     void setDurationWeight(double durationWeight);
@@ -60,11 +60,11 @@ signals:
     void durationAtAttenuationThresholdsChanged();
 
 private:
-    quint8 m_minimumRiskScore;
-    QList<quint32> m_attenuationScores;
-    QList<quint32> m_daysSinceLastExposureScores;
-    QList<quint32> m_durationScores;
-    QList<quint32> m_transmissionRiskScores;
+    qint32 m_minimumRiskScore;
+    QList<qint32> m_attenuationScores;
+    QList<qint32> m_daysSinceLastExposureScores;
+    QList<qint32> m_durationScores;
+    QList<qint32> m_transmissionRiskScores;
 
     double m_attenuationWeight;
     double m_daysSinceLastExposureWeight;

--- a/contracd/src/exposurenotification.cpp
+++ b/contracd/src/exposurenotification.cpp
@@ -14,6 +14,7 @@
 #include "exposurenotification_p.h"
 
 #define MAX_DIAGNOSIS_KEYS (1024)
+// The spaces are intentional, to pad to 16 bytes
 #define EXPORT_BIN_HEADER QLatin1String("EK Export v1    ")
 
 // In milliseconds
@@ -21,7 +22,7 @@
 
 namespace {
 
-inline quint32 checkLowerThreshold(qint32 thresholds[8], QList<quint32> scores, qint32 value)
+inline qint32 checkLowerThreshold(qint32 thresholds[8], QList<qint32> scores, qint32 value)
 {
     qint8  pos = 7;
     while ((pos > 0) && (value < thresholds[pos - 1])) {
@@ -31,7 +32,7 @@ inline quint32 checkLowerThreshold(qint32 thresholds[8], QList<quint32> scores, 
     return scores[pos];
 }
 
-inline quint32 checkGreaterThreshold(qint32 thresholds[8], QList<quint32> scores, qint32 value)
+inline qint32 checkGreaterThreshold(qint32 thresholds[8], QList<qint32> scores, qint32 value)
 {
     qint8 pos = 7;
     while ((pos > 0) && (value > thresholds[pos - 1])) {
@@ -309,7 +310,7 @@ QList<ExposureInformation> ExposureNotificationPrivate::aggregateExposureData(qu
 
             qint64 interval = match.m_rpis[rpi_pos].m_interval;
             totalDuration = 0;
-            quint32 totalRiskScore;
+            qint32 totalRiskScore;
             qint32 attenuationDurations[3] = {0, 0, 0};
             qint64 attenuationSum = 0;
             while (rpi_pos < match.m_rpis.size() && (match.m_rpis[rpi_pos].m_interval < interval + (CONTIGUOUS_PERIOD_THRESHOLD / CTINTERVAL_DURATION) + 1)) {
@@ -369,7 +370,7 @@ QList<ExposureInformation> ExposureNotificationPrivate::aggregateExposureData(qu
             //days_ago = static_cast<qint32>(dayNumber) - static_cast<qint32>(m_contrac->dayNumber());
             totalRiskScore = calculateRiskScore(configuration, transmissionRisk, totalDuration, days_ago, attenuationValue);
 
-            exposure.setTotalRiskScore(static_cast<qint32>(totalRiskScore));
+            exposure.setTotalRiskScore(totalRiskScore);
 
             exposures.append(exposure);
         }
@@ -378,13 +379,13 @@ QList<ExposureInformation> ExposureNotificationPrivate::aggregateExposureData(qu
     return exposures;
 }
 
-quint32 ExposureNotificationPrivate::calculateRiskScore(ExposureConfiguration const &configuration, qint32 transmissionRisk, qint32 duration, qint32 days_ago, qint32 attenuationValue)
+qint32 ExposureNotificationPrivate::calculateRiskScore(ExposureConfiguration const &configuration, qint32 transmissionRisk, qint32 duration, qint32 days_ago, qint32 attenuationValue)
 {
-    quint32 riskScore;
-    quint32 attenuationScore;
-    quint32 daysSinceLastExposureScore;
-    quint32 durationScore;
-    quint32 transmissionRiskScore;
+    qint32 riskScore;
+    qint32 attenuationScore;
+    qint32 daysSinceLastExposureScore;
+    qint32 durationScore;
+    qint32 transmissionRiskScore;
     qint8 pos;
 
     qint32 attenuationThresholds[8] = {73, 63, 51, 33, 27, 15, 10};
@@ -435,14 +436,21 @@ bool ExposureNotificationPrivate::loadDiagnosisKeys(QString const &keyFile, diag
         stream.read(header.data(), 16);
 
         result = (header == QString(EXPORT_BIN_HEADER));
+
         if (result) {
             result = keyExport->ParseFromIstream(&stream);
-            qDebug() << "Diagnosis file region: " << keyExport->region().data();
-            qDebug() << "Diagnosis file start timestamp: " << keyExport->start_timestamp();
-            qDebug() << "Diagnosis file end timestamp: " << keyExport->end_timestamp();
-            qDebug() << "Diagnosis file keys: " << keyExport->keys().size();
-            qDebug() << "Diagnosis file verification key: " << keyExport->signature_infos().size();
         }
+    }
+
+    if (result) {
+        qDebug() << "Diagnosis file region: " << keyExport->region().data();
+        qDebug() << "Diagnosis file start timestamp: " << keyExport->start_timestamp();
+        qDebug() << "Diagnosis file end timestamp: " << keyExport->end_timestamp();
+        qDebug() << "Diagnosis file keys: " << keyExport->keys().size();
+        qDebug() << "Diagnosis file verification key: " << keyExport->signature_infos().size();
+    }
+    else {
+        qDebug() << "TemporaryExposureKeyExport proto file failed to load";
     }
 
     return result;

--- a/contracd/src/exposurenotification.cpp
+++ b/contracd/src/exposurenotification.cpp
@@ -499,6 +499,7 @@ ExposureSummary ExposureNotification::getExposureSummary(QString const &token) c
             summationRiskScore += exposure.totalRiskScore();
         }
         day = static_cast<quint32>(mostRecent / (24 * 60 * 60 * 1000));
+        day += 12;
 
         summary.setDaysSinceLastExposure(day);
         summary.setMatchedKeyCount(static_cast<quint32>(exposureInfoList.count()));
@@ -590,4 +591,3 @@ void ExposureNotification::onRpiChanged()
 
     emit beaconSent();
 }
-

--- a/contracd/src/exposurenotification_p.h
+++ b/contracd/src/exposurenotification_p.h
@@ -22,7 +22,7 @@ public:
 
     static bool loadDiagnosisKeys(QString const &keyFile, diagnosis::TemporaryExposureKeyExport * keyExport);
     static QList<ExposureInformation> aggregateExposureData(quint32 dayNumber, ExposureConfiguration const &configuration, QList<ContactMatch> matches, qint32 const days_ago);
-    static quint32 calculateRiskScore(ExposureConfiguration const &configuration, qint32 transmissionRisk, qint32 duration, qint32 days_ago, qint32 attenuationValue);
+    static qint32 calculateRiskScore(ExposureConfiguration const &configuration, qint32 transmissionRisk, qint32 duration, qint32 days_ago, qint32 attenuationValue);
 
 private:
     ExposureNotification *q_ptr;

--- a/contracd/src/exposuresummary.cpp
+++ b/contracd/src/exposuresummary.cpp
@@ -1,4 +1,5 @@
 #include <QDebug>
+#include <QDataStream>
 
 #include "exposuresummary.h"
 
@@ -34,6 +35,19 @@ ExposureSummary& ExposureSummary::operator=( const ExposureSummary &other)
     return *this;
 }
 
+bool ExposureSummary::operator==( const ExposureSummary &other)
+{
+    bool same;
+    same = (m_daysSinceLastExposure == other.m_daysSinceLastExposure) && (m_matchedKeyCount == other.m_matchedKeyCount) && (m_maximumRiskScore == other.m_maximumRiskScore) && (m_attenuationDurations == other.m_attenuationDurations) && (m_summationRiskScore == other.m_summationRiskScore);
+
+    return same;
+}
+
+bool ExposureSummary::operator!=( const ExposureSummary &other)
+{
+    return !(*this == other);
+}
+
 QDBusArgument &operator<<(QDBusArgument &argument, const ExposureSummary &exposureSummary)
 {
     argument.beginStructure();
@@ -67,6 +81,37 @@ QDBusArgument const &operator>>(const QDBusArgument &argument, ExposureSummary &
     argument.endStructure();
 
     return argument;
+}
+
+QDataStream &operator<<(QDataStream &out, const ExposureSummary &exposureSummary)
+{
+    out << exposureSummary.daysSinceLastExposure();
+    out << exposureSummary.matchedKeyCount();
+    out << exposureSummary.maximumRiskScore();
+    out << exposureSummary.attenuationDurations();
+    out << exposureSummary.summationRiskScore();
+
+    return out;
+}
+
+QDataStream &operator>>(QDataStream &in, ExposureSummary &exposureSummary)
+{
+    quint32 valueUnsignedInt;
+    qint32 valueSignedInt;
+    QList<qint32> valueList;
+
+    in >> valueUnsignedInt;
+    exposureSummary.setDaysSinceLastExposure(valueUnsignedInt);
+    in >> valueUnsignedInt;
+    exposureSummary.setMatchedKeyCount(valueUnsignedInt);
+    in >> valueSignedInt;
+    exposureSummary.setMaximumRiskScore(valueSignedInt);
+    in >> valueList;
+    exposureSummary.setAttenuationDurations(valueList);
+    in >> valueSignedInt;
+    exposureSummary.setSummationRiskScore(valueSignedInt);
+
+    return in;
 }
 
 quint32 ExposureSummary::daysSinceLastExposure() const

--- a/contracd/src/exposuresummary.cpp
+++ b/contracd/src/exposuresummary.cpp
@@ -3,8 +3,12 @@
 #include "exposuresummary.h"
 
 ExposureSummary::ExposureSummary(QObject *parent) : QObject(parent)
+  , m_daysSinceLastExposure(0)
+  , m_matchedKeyCount(0)
+  , m_maximumRiskScore(0)
+  , m_attenuationDurations()
+  , m_summationRiskScore(0)
 {
-
 }
 
 ExposureSummary::ExposureSummary(ExposureSummary const &exposureSummary)

--- a/contracd/src/exposuresummary.h
+++ b/contracd/src/exposuresummary.h
@@ -16,6 +16,8 @@ public:
     explicit ExposureSummary(QObject *parent = nullptr);
     ExposureSummary(ExposureSummary const &exposureSummary);
     ExposureSummary& operator=( const ExposureSummary &other);
+    bool operator==( const ExposureSummary &other);
+    bool operator!=( const ExposureSummary &other);
 
     quint32 daysSinceLastExposure() const;
     quint32 matchedKeyCount() const;
@@ -47,6 +49,8 @@ private:
 
 QDBusArgument &operator<<(QDBusArgument &argument, const ExposureSummary &exposureSummary);
 QDBusArgument const &operator>>(const QDBusArgument &argument, ExposureSummary &exposureSummary);
+QDataStream &operator<<(QDataStream &out, const ExposureSummary &exposureSummary);
+QDataStream &operator>>(QDataStream &in, ExposureSummary &exposureSummary);
 
 Q_DECLARE_METATYPE(ExposureSummary)
 

--- a/qml/pages/DownloadInfo.qml
+++ b/qml/pages/DownloadInfo.qml
@@ -47,6 +47,7 @@ Page {
                     left: parent.left
                     right: parent.right
                 }
+                color: Theme.highlightColor
             }
 
             ProgressCircle {
@@ -79,7 +80,8 @@ Page {
                         if (download.status === Download.StatusError) {
                             return errorString()
                         } else if (download.status === Download.StatusIdle) {
-                            return "Completed"
+                            //% "Completed"
+                            return qsTrId("contrac-download_la_completed")
                         }
                     }
                     return Math.round(downloadProgress.value * 100.0) + "%"
@@ -93,6 +95,7 @@ Page {
                     left: parent.left
                     right: parent.right
                 }
+                color: Theme.highlightColor
             }
         }
     }
@@ -101,6 +104,6 @@ Page {
         interval: 5 * 1000
         repeat: false
         onTriggered: pageStack.pop()
-        running: download.status === Download.StatusIdle
+        running: downloadProgress.value >= 1.0
     }
 }

--- a/qml/pages/Main.qml
+++ b/qml/pages/Main.qml
@@ -8,7 +8,8 @@ Page {
     property string token: "abcdef"
     property alias upload: upload
     property alias download: download
-    property ExposureSummary summary;
+    property bool updating
+    property bool updatePending
 
     allowedOrientations: Orientation.All
 
@@ -30,15 +31,39 @@ Page {
         return result
     }
 
+    function translateRiskScore(risk) {
+        if (risk < 15) {
+            return "Low"
+        } else {
+            return "Ligh"
+        }
+    }
+
+    function performUpdate() {
+        updatePending = false
+        var filelist = download.fileList()
+        console.log("Files to check: " + filelist.length)
+        updating = true
+        dbusproxy.provideDiagnosisKeys(filelist, download.config, token)
+    }
+
     Download {
         id: download
         property bool available: moreThanADayAgo(latest)
-        onDownloadComplete: {
-            var keyfiles = [ filename ]
+        onAllFilesDownloaded: {
+            // The download just finished
+            if (page.status === PageStatus.Active) {
+                performUpdate()
+            }
+            else {
+                updatePending = true
+            }
+        }
+    }
 
-            console.log("Checking: " + filename)
-
-            dbusproxy.provideDiagnosisKeys(keyfiles, config, token)
+    onStatusChanged: {
+        if (status === PageStatus.Active && updatePending) {
+            performUpdate()
         }
     }
 
@@ -49,6 +74,25 @@ Page {
 
     DBusProxy {
         id: dbusproxy
+
+        onProvideDiagnosisKeysResult: {
+            var summary
+            if (token == page.token) {
+                updating = false;
+
+                if (status == DBusProxy.Success) {
+                    console.log("Exposure summary")
+                    summary = dbusproxy.getExposureSummary(token);
+                    console.log("Attenuation durations: " + summary.attenuationDurations)
+                    console.log("Days since last exposure: " + summary.daysSinceLastExposure)
+                    console.log("Matched key count: " + summary.matchedKeyCount)
+                    console.log("Maximum risk score: " + summary.maximumRiskScore)
+                    console.log("Summation risk score: " + summary.summationRiskScore)
+                    Settings.summaryUpdated = new Date()
+                    Settings.latestSummary = summary
+                }
+            }
+        }
     }
 
     SilicaListView {
@@ -88,8 +132,136 @@ Page {
             }
 
             SectionHeader {
-                //% "Contact beacons"
-                text: qsTrId("contrac-main_contact_beacons")
+                //% "Status"
+                text: qsTrId("contrac-main_he_status")
+            }
+
+            Item {
+                x: Theme.horizontalPageMargin
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                height: Theme.itemSizeSmall
+
+                BusyIndicator {
+                    id: progress
+                    anchors.verticalCenter: parent.verticalCenter
+                    running: true
+                    size: BusyIndicatorSize.Small
+                    visible: upload.uploaindg || download.downloading || updating || dbusproxy.isBusy
+                }
+
+                Image {
+                    anchors.fill: progress
+                    visible: !progress.visible
+                    source: (upload.status === Upload.StatusError) || (download.status === Download.StatusError) || (!dbusproxy.isEnabled) || (Settings.latestSummary.summationRiskScore >= 15)? "image://theme/icon-s-warning" : "image://theme/icon-s-installed"
+                }
+
+                Label {
+                    id: statusLabel
+                    anchors {
+                        verticalCenter: parent.verticalCenter
+                        left: progress.right
+                        right: parent.right
+                        leftMargin: Theme.paddingMedium
+                    }
+
+                    text: {
+                        if (updating) {
+                            //% "Updating"
+                            return qsTrId("contrac-main_la_status-updating")
+                        } else if (upload.uploading) {
+                            //% "Uploading"
+                            return qsTrId("contrac-main_la_status-uploading")
+                        } else if (download.downloading) {
+                            //% "Downloading"
+                            return qsTrId("contrac-main_la_status-downloading")
+                        } else if (upload.status === Upload.StatusError) {
+                            //% "Error uploading"
+                            return qsTrId("contrac-main_la_status-upload_error")
+                        } else if (download.status === Download.StatusError) {
+                            //% "Error downloading"
+                            return qsTrId("contrac-main_la_status-download_error")
+                        } else if (dbusproxy.isBusy) {
+                            //% "Busy"
+                            return qsTrId("contrac-main_la_status-busy")
+                        } else if (Settings.latestSummary.summationRiskScore >= 15) {
+                            //% "At risk"
+                            return qsTrId("contrac-main_la_status-at-rsk")
+                        } else if (dbusproxy.isEnabled) {
+                            //% "Active"
+                            return qsTrId("contrac-main_la_status-active")
+                        } else {
+                            //% "Disabled"
+                            return qsTrId("contrac-main_la_status-disabled")
+                        }
+                    }
+                    color: Theme.highlightColor
+                }
+            }
+
+            Label {
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                x: Theme.horizontalPageMargin
+                //% "Risk status"
+                text: qsTrId("contrac-main_la_risk-status") + " : " + (!isNaN(Settings.summaryUpdated)
+                                                                       ? translateRiskScore(Settings.latestSummary.summationRiskScore)
+                                                                         //% "Unknown"
+                                                                       : qsTrId("contrac-main_la_risk-status-unknown"))
+                color: Theme.highlightColor
+                wrapMode: Text.Wrap
+            }
+
+            Label {
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                x: Theme.horizontalPageMargin
+                //% "Latest update"
+                text: qsTrId("contrac-main_la_last-update") + " : " + (!isNaN(Settings.summaryUpdated)
+                                                                       ? Qt.formatDateTime(Settings.summaryUpdated, "d MMM yyyy, hh:mm")
+                                                                         //% "Never"
+                                                                       : qsTrId("contrac-main_la_latest-update-never"))
+                color: Theme.highlightColor
+                wrapMode: Text.Wrap
+            }
+
+            Label {
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                x: Theme.horizontalPageMargin
+                //% "Days since last exposure"
+                text: qsTrId("contrac-main_la_days-since-last-exposure") + " : " + (Settings.latestSummary.matchedKeyCount > 0
+                                                                                    ? Settings.latestSummary.daysSinceLastExposure
+                                                                                      //% "None recorded"
+                                                                                    : qsTrId("contrac-main_la_days-since-last-exposure-none"))
+                color: Theme.highlightColor
+                wrapMode: Text.Wrap
+            }
+
+            Label {
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                x: Theme.horizontalPageMargin
+                //% "Number of matched keys"
+                text: qsTrId("contrac-main_la_matched-keys") + " : " + Settings.latestSummary.matchedKeyCount
+                color: Theme.highlightColor
+                wrapMode: Text.Wrap
+            }
+
+            Label {
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                x: Theme.horizontalPageMargin
+                //% "Sent"
+                text: qsTrId("contrac-main_sent") + " : " + dbusproxy.sentCount
+                color: Theme.highlightColor
+            }
+
+            Label {
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                x: Theme.horizontalPageMargin
+                //% "Received"
+                text: qsTrId("contrac-main_received") + " : " + dbusproxy.receivedCount
+                color: Theme.highlightColor
+            }
+
+            SectionHeader {
+                //% "Control"
+                text: qsTrId("contrac-main_bt_actions")
             }
 
             TextSwitch {
@@ -111,93 +283,6 @@ Page {
                 }
             }
 
-            Label {
-                width: parent.width - 2 * Theme.horizontalPageMargin
-                x: Theme.horizontalPageMargin
-                //% "Sent"
-                text: qsTrId("contrac-main_sent") + " : " + dbusproxy.sentCount
-                color: Theme.highlightColor
-            }
-
-            Label {
-                width: parent.width - 2 * Theme.horizontalPageMargin
-                x: Theme.horizontalPageMargin
-                //% "Received"
-                text: qsTrId("contrac-main_received") + " : " + dbusproxy.receivedCount
-                color: Theme.highlightColor
-            }
-
-            SectionHeader {
-                //% "Diagnosis keys"
-                text: qsTrId("contrac-main_diagnosis_keys")
-            }
-
-            Label {
-                width: parent.width - 2 * Theme.horizontalPageMargin
-                x: Theme.horizontalPageMargin
-                //% "Latest upload: "
-                text: qsTrId("contrac-main_la_latest-upload") + Qt.formatDate(upload.latest, "d MMM yyyy")
-                color: Theme.highlightColor
-            }
-
-            Label {
-                width: parent.width - 2 * Theme.horizontalPageMargin
-                x: Theme.horizontalPageMargin
-                //% "Latest download: "
-                text: qsTrId("contrac-main_la_latest-download") + Qt.formatDate(download.latest, "d MMM yyyy")
-                color: Theme.highlightColor
-            }
-
-            Item {
-                x: Theme.horizontalPageMargin
-                width: parent.width - 2 * Theme.horizontalPageMargin
-                height: Theme.itemSizeSmall
-
-                BusyIndicator {
-                    id: progress
-                    anchors.verticalCenter: parent.verticalCenter
-                    running: true
-                    size: BusyIndicatorSize.Small
-                    visible: upload.uploaindg || download.downloading
-                }
-
-                Image {
-                    anchors.fill: progress
-                    visible: !progress.visible
-                    source: (upload.status === Upload.StatusError) || (download.status === Download.StatusError) ? "image://theme/icon-s-warning" : "image://theme/icon-s-installed"
-                }
-
-                Label {
-                    id: statusLabel
-                    anchors {
-                        verticalCenter: parent.verticalCenter
-                        left: progress.right
-                        right: parent.right
-                        leftMargin: Theme.paddingMedium
-                    }
-
-                    text: {
-                        if (upload.uploading) {
-                            //% "Uploading"
-                            return qsTrId("contrac-main_la_status-uploading")
-                        } else if (download.downloading) {
-                            //% "Downloading"
-                            return qsTrId("contrac-main_la_status-downloading")
-                        } else if (upload.status === Upload.StatusError) {
-                            //% "Error uploading"
-                            return qsTrId("contrac-main_la_status-upload_error")
-                        } else if (download.status === Download.StatusError) {
-                            //% "Error downloading"
-                            return qsTrId("contrac-main_la_status-download_err0r")
-                        } else {
-                            //% "No issues"
-                            return qsTrId("contrac-main_la_status-no_ssues")
-                        }
-                    }
-                    color: Theme.highlightColor
-                }
-            }
-
             Button {
                 id: tanButton
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -214,31 +299,12 @@ Page {
                 id: downloadButton
                 anchors.horizontalCenter: parent.horizontalCenter
                 width: Math.max(tanButton.implicitWidth, downloadButton.implicitWidth)
-                enabled: !download.downloading
-                //% "Download latest keys"
-                text: qsTrId("contrac-main_bu_download-keys")
+                enabled: !download.downloading && download.available
+                //% "Perform daily update"
+                text: qsTrId("contrac-main_bu_daily-update")
                 onClicked: {
                     download.downloadLatest()
                     pageStack.push(Qt.resolvedUrl("DownloadInfo.qml"), {download: page.download})
-                }
-            }
-
-            Button {
-                id: performCheckButton
-                anchors.horizontalCenter: parent.horizontalCenter
-                width: Math.max(tanButton.implicitWidth, downloadButton.implicitWidth)
-                enabled: !download.downloading
-                text: "Perform check"
-                onClicked: {
-                    var filelist = download.fileList();
-                    console.log("Files to check: " + filelist.length);
-                    dbusproxy.provideDiagnosisKeys(filelist, download.config, token);
-                    summary = dbusproxy.getExposureSummary(token);
-                    console.log("Attenuation durations: " + summary.attenuationDurations)
-                    console.log("Days since last exposure: " + summary.daysSinceLastExposure)
-                    console.log("Matched key count: " + summary.matchedKeyCount)
-                    console.log("Maximum risk score: " + summary.maximumRiskScore)
-                    console.log("Summation risk score: " + summary.summationRiskScore)
                 }
             }
         }

--- a/qml/pages/Main.qml
+++ b/qml/pages/Main.qml
@@ -8,6 +8,7 @@ Page {
     property string token: "abcdef"
     property alias upload: upload
     property alias download: download
+    property ExposureSummary summary;
 
     allowedOrientations: Orientation.All
 
@@ -44,10 +45,6 @@ Page {
     Upload {
         id: upload
         property bool available: moreThanADayAgo(latest)
-    }
-
-    DownloadConfig {
-        id: downloadConfig
     }
 
     DBusProxy {
@@ -227,15 +224,21 @@ Page {
             }
 
             Button {
-                id: downloadConfigButton
+                id: performCheckButton
                 anchors.horizontalCenter: parent.horizontalCenter
                 width: Math.max(tanButton.implicitWidth, downloadButton.implicitWidth)
                 enabled: !download.downloading
                 text: "Perform check"
                 onClicked: {
-                    var filelist;
+                    var filelist = download.fileList();
+                    console.log("Files to check: " + filelist.length);
                     dbusproxy.provideDiagnosisKeys(filelist, download.config, token);
-                    //downloadConfig.downloadLatest()
+                    summary = dbusproxy.getExposureSummary(token);
+                    console.log("Attenuation durations: " + summary.attenuationDurations)
+                    console.log("Days since last exposure: " + summary.daysSinceLastExposure)
+                    console.log("Matched key count: " + summary.matchedKeyCount)
+                    console.log("Maximum risk score: " + summary.maximumRiskScore)
+                    console.log("Summation risk score: " + summary.summationRiskScore)
                 }
             }
         }

--- a/qml/pages/Main.qml
+++ b/qml/pages/Main.qml
@@ -16,10 +16,6 @@ Page {
         updateFrequency: WallClock.Day
     }
 
-    ExposureConfiguration {
-        id: config
-    }
-
     function moreThanADayAgo(latest) {
         var result = true
         if (!isNaN(latest)) {
@@ -48,6 +44,10 @@ Page {
     Upload {
         id: upload
         property bool available: moreThanADayAgo(latest)
+    }
+
+    DownloadConfig {
+        id: downloadConfig
     }
 
     DBusProxy {
@@ -223,6 +223,19 @@ Page {
                 onClicked: {
                     download.downloadLatest()
                     pageStack.push(Qt.resolvedUrl("DownloadInfo.qml"), {download: page.download})
+                }
+            }
+
+            Button {
+                id: downloadConfigButton
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: Math.max(tanButton.implicitWidth, downloadButton.implicitWidth)
+                enabled: !download.downloading
+                text: "Perform check"
+                onClicked: {
+                    var filelist;
+                    dbusproxy.provideDiagnosisKeys(filelist, download.config, token);
+                    //downloadConfig.downloadLatest()
                 }
             }
         }

--- a/src/applicationConfiguration.proto
+++ b/src/applicationConfiguration.proto
@@ -1,0 +1,134 @@
+// For downloading the Exposure Notification configuration
+
+syntax = "proto3";
+
+package diagnosis;
+
+option optimize_for = LITE_RUNTIME;
+
+message ApplicationConfiguration {
+
+    int32 minRiskScore = 1;
+
+    RiskScoreClassification riskScoreClasses = 2;
+
+    RiskScoreParameters exposureConfig = 3;
+
+    AttenuationDuration attenuationDuration = 4;
+
+    ApplicationVersionConfiguration appVersion = 5;
+}
+
+message RiskScoreParameters {
+
+    // App-specific mapping
+    TransmissionRiskParameter transmission = 1;
+    double transmissionWeight = 2;
+
+    DurationRiskParameter duration = 3;
+    double durationWeight = 4;
+
+    DaysSinceLastExposureRiskParameter daysSinceLastExposure = 5;
+    double daysWeight= 6;
+
+    AttenuationRiskParameter attenuation = 7;
+    double attenuationWeight= 8;
+
+    message TransmissionRiskParameter {
+        RiskLevel appDefined_1 = 1;
+        RiskLevel appDefined_2 = 2;
+        RiskLevel appDefined_3 = 3;
+        RiskLevel appDefined_4 = 4;
+        RiskLevel appDefined_5 = 5;
+        RiskLevel appDefined_6 = 6;
+        RiskLevel appDefined_7 = 7;
+        RiskLevel appDefined_8 = 8;
+    }
+    message DurationRiskParameter {
+        RiskLevel eq_0_min = 1;             // D = 0 min, lowest risk
+        RiskLevel gt_0_le_5_min = 2;        // 0 < D <= 5 min
+        RiskLevel gt_5_le_10_min = 3;       // 5 < D <= 10 min
+        RiskLevel gt_10_le_15_min = 4;      // 10 < D <= 15 min
+        RiskLevel gt_15_le_20_min = 5;      // 15 < D <= 20 min
+        RiskLevel gt_20_le_25_min = 6;      // 20 < D <= 25 min
+        RiskLevel gt_25_le_30_min = 7;      // 25 < D <= 30 min
+        RiskLevel gt_30_min = 8;            // > 30 min, highest risk
+    }
+    message DaysSinceLastExposureRiskParameter {
+        RiskLevel ge_14_days = 1;           // D >= 14 days, lowest risk
+        RiskLevel ge_12_lt_14_days = 2;     // 12 <= D < 14 days
+        RiskLevel ge_10_lt_12_days = 3;     // 10 <= D < 12 days
+        RiskLevel ge_8_lt_10_days = 4;      // 8 <= D < 10 days
+        RiskLevel ge_6_lt_8_days = 5;       // 6 <= D < 8 days
+        RiskLevel ge_4_lt_6_days = 6;       // 4 <= D < 6 days
+        RiskLevel ge_2_lt_4_days = 7;       // 2 <= D < 4 days
+        RiskLevel ge_0_lt_2_days = 8;       // 0 <= D < 2 days, highest risk
+    }
+    message AttenuationRiskParameter {
+        RiskLevel gt_73_dbm = 1;            // A > 73 dBm, lowest risk
+        RiskLevel gt_63_le_73_dbm = 2;      // 63 < A <= 73 dBm
+        RiskLevel gt_51_le_63_dbm = 3;      // 51 < A <= 63 dBm
+        RiskLevel gt_33_le_51_dbm = 4;      // 33 < A <= 51 dBm
+        RiskLevel gt_27_le_33_dbm = 5;      // 27 < A <= 33 dBm
+        RiskLevel gt_15_le_27_dbm = 6;      // 15 < A <= 27 dBm
+        RiskLevel gt_10_le_15_dbm = 7;      // 10 < A <= 15 dBm
+        RiskLevel lt_10_dbm = 8;            // A <= 10 dBm, highest risk
+    }
+}
+
+enum RiskLevel {
+    INVALID = 0;
+    LOWEST = 1;
+    LOW = 2;
+    LOW_MEDIUM = 3;
+    MEDIUM = 4;
+    MEDIUM_HIGH = 5;
+    HIGH = 6;
+    VERY_HIGH = 7;
+    HIGHEST = 8;
+}
+
+message RiskScoreClassification {
+    repeated RiskScoreClass risk_classes = 1;
+}
+
+message RiskScoreClass {
+    string label = 1;
+    int32 min = 2;
+    int32 max = 3;
+    string url = 4;
+}
+
+message AttenuationDuration {
+    Thresholds thresholds = 1;
+    Weights weights = 2;
+    int32 defaultBucketOffset = 3;
+    int32 riskScoreNormalizationDivisor = 4;
+}
+
+message Thresholds {
+    int32 lower = 1;
+    int32 upper = 2;
+}
+
+message Weights {
+    double low = 1;
+    double mid = 2;
+    double high = 3;
+}
+
+message ApplicationVersionConfiguration {
+    ApplicationVersionInfo ios = 1;
+    ApplicationVersionInfo android = 2;
+}
+
+message ApplicationVersionInfo {
+    SemanticVersion latest = 1;
+    SemanticVersion min = 2;
+}
+
+message SemanticVersion {
+    uint32 major = 1;
+    uint32 minor = 2;
+    uint32 patch = 3;
+}

--- a/src/dbusproxy.h
+++ b/src/dbusproxy.h
@@ -67,6 +67,9 @@ signals:
     void sentCountChanged();
     void isBusyChanged();
 
+    // Async responses
+    void provideDiagnosisKeysResult(Status status, QString const &token);
+
 public slots:
 
 private:

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -298,3 +298,34 @@ ExposureConfiguration const *Download::config() const
 {
     return m_downloadConfig->config();
 }
+
+QStringList Download::fileList() const
+{
+    QDir root = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/download/";
+    QStringList result;
+
+    root.setFilter(QDir::Dirs | QDir::NoDotAndDotDot | QDir::Readable);
+    root.setNameFilters(QStringList(QStringLiteral("\?\?\?\?-\?\?-\?\?")));
+    root.setSorting(QDir::Name);
+    QFileInfoList dirs = root.entryInfoList();
+
+    QRegExp dateFormat("\\d{4}-\\d{2}-\\d{2}");
+    QRegExp hourFormat("\\d{1,2}");
+    for (QFileInfo dir : dirs) {
+        if (dateFormat.exactMatch(dir.fileName())) {
+            QDir day(dir.absoluteFilePath());
+            day.setFilter(QDir::Files | QDir::NoDotAndDotDot | QDir::Readable);
+            day.setNameFilters(QStringList(QStringLiteral("\?\?")) << QStringLiteral("\?"));
+            day.setSorting(QDir::Name);
+            QFileInfoList hours = day.entryInfoList();
+            for (QFileInfo hour : hours) {
+                if (hourFormat.exactMatch(hour.fileName())) {
+                    result << hour.absoluteFilePath();
+                }
+            }
+        }
+    }
+
+    return result;
+}
+

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -24,6 +24,8 @@ Download::Download(QObject *parent) : QObject(parent)
     m_s3Access->setBaseUrl(Settings::getInstance().downloadServer());
     m_s3Access->setBucket("cwa");
 
+    m_latest = Settings::getInstance().summaryUpdated().date();
+
     connect(m_downloadConfig, &DownloadConfig::configChanged, this, &Download::configChanged);
     connect(m_downloadConfig, &DownloadConfig::downloadComplete, this, &Download::configDownloadComplete);
 }
@@ -171,7 +173,9 @@ void Download::startNextDateDownload()
     else {
         qDebug() << "All dates downloaded";
         finalise();
+        downloading = m_downloading;
         setStatus(StatusIdle);
+        emit allFilesDownloaded();
     }
 
     if (m_downloading != downloading) {

--- a/src/download.h
+++ b/src/download.h
@@ -5,9 +5,10 @@
 #include <QDate>
 #include <QMap>
 
+#include "../contracd/src/exposureconfiguration.h"
+
 class S3Access;
 class DownloadConfig;
-class ExposureConfiguration;
 
 class Download : public QObject
 {
@@ -37,6 +38,7 @@ public:
     explicit Download(QObject *parent = nullptr);
 
     Q_INVOKABLE void downloadLatest();
+    Q_INVOKABLE QStringList fileList() const;
 
     QDate latest() const;
     bool downloading() const;

--- a/src/download.h
+++ b/src/download.h
@@ -55,6 +55,7 @@ signals:
     void statusChanged();
     void errorChanged();
     void configChanged();
+    void allFilesDownloaded();
 
 private slots:
     void setStatus(Status status);

--- a/src/downloadconfig.cpp
+++ b/src/downloadconfig.cpp
@@ -1,0 +1,257 @@
+#include <QStandardPaths>
+
+#include "../contracd/src/exposureconfiguration.h"
+#include "../contracd/src/zipistreambuffer.h"
+
+#include "settings.h"
+#include "s3access.h"
+#include "proto/applicationConfiguration.pb.h"
+
+#include "downloadconfig.h"
+
+#define CONFIG_FILENAME QStringLiteral("/download/file.config")
+
+DownloadConfig::DownloadConfig(QObject *parent) : QObject(parent)
+  , m_s3Access(new S3Access(this))
+  , m_downloading(false)
+  , m_status(StatusIdle)
+  , m_configuration(new ExposureConfiguration(this))
+{
+    m_s3Access->setId("accessKey1");
+    m_s3Access->setSecret("verySecretKey1");
+    m_s3Access->setBaseUrl(Settings::getInstance().downloadServer());
+    m_s3Access->setBucket("cwa");
+
+    connect(m_configuration, &ExposureConfiguration::minimumRiskScoreChanged, this, &DownloadConfig::configChanged);
+    connect(m_configuration, &ExposureConfiguration::attenuationScoresChanged, this, &DownloadConfig::configChanged);
+    connect(m_configuration, &ExposureConfiguration::daysSinceLastExposureScoresChanged, this, &DownloadConfig::configChanged);
+    connect(m_configuration, &ExposureConfiguration::durationScoresChanged, this, &DownloadConfig::configChanged);
+    connect(m_configuration, &ExposureConfiguration::transmissionRiskScoresChanged, this, &DownloadConfig::configChanged);
+    connect(m_configuration, &ExposureConfiguration::attenuationWeightChanged, this, &DownloadConfig::configChanged);
+    connect(m_configuration, &ExposureConfiguration::daysSinceLastExposureWeightChanged, this, &DownloadConfig::configChanged);
+    connect(m_configuration, &ExposureConfiguration::durationWeightChanged, this, &DownloadConfig::configChanged);
+    connect(m_configuration, &ExposureConfiguration::transmissionRiskWeightChanged, this, &DownloadConfig::configChanged);
+    connect(m_configuration, &ExposureConfiguration::durationAtAttenuationThresholdsChanged, this, &DownloadConfig::configChanged);
+
+    qDebug() << "DownloadConfig created";
+}
+
+Q_INVOKABLE void DownloadConfig::downloadLatest()
+{
+    qDebug() << "Requesting configuration";
+
+    if (!m_downloading) {
+        m_s3Access->setBaseUrl(Settings::getInstance().downloadServer());
+        setStatus(StatusDownloading);
+
+        QString key = "version/v1/configuration/country/DE/app_config";
+        QString filename = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + CONFIG_FILENAME;
+        qDebug() << "Saving to:" << filename;
+        S3GetFileResult *result = m_s3Access->getFile(key, filename);
+        connect(result, &S3Result::finished, this, [this, result, filename]() {
+            qDebug() << "Finished downloading configuration";
+            finalise();
+            switch (result->error()) {
+            case QNetworkReply::NoError:
+                qDebug() << "DownloadConfig NoError";
+                setStatus(StatusIdle);
+                loadConfig();
+                break;
+            default:
+                qDebug() << "Network error while downloading keys: " << result->error();
+                setStatusError(ErrorNetwork);
+                break;
+            }
+
+            emit downloadComplete(filename);
+            result->deleteLater();
+        });
+
+        m_downloading = true;
+        emit downloadingChanged();
+    }
+}
+
+void DownloadConfig::finalise()
+{
+    if (m_downloading) {
+        m_downloading = false;
+        qDebug() << "DownloadConfig finalised";
+
+        emit downloadingChanged();
+    }
+}
+
+DownloadConfig::Status DownloadConfig::status() const
+{
+    return m_status;
+}
+
+void DownloadConfig::setStatus(Status status)
+{
+    if (m_status != status) {
+        qDebug() << "Setting status: " << status;
+        m_status = status;
+
+        if (m_error != ErrorNone) {
+            m_error = ErrorNone;
+            emit errorChanged();
+        }
+        emit statusChanged();
+    }
+}
+
+DownloadConfig::ErrorType DownloadConfig::error() const
+{
+    return m_error;
+}
+
+void DownloadConfig::setStatusError(ErrorType error)
+{
+    if (m_error != error) {
+        qDebug() << "Setting error: " << error;
+        m_error = error;
+
+        if (m_status != StatusError) {
+            m_status = StatusError;
+            emit statusChanged();
+        }
+        emit errorChanged();
+    }
+}
+
+bool DownloadConfig::downloading() const
+{
+    return m_downloading;
+}
+
+bool DownloadConfig::loadConfig()
+{
+    QString filename = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + CONFIG_FILENAME;
+
+    QuaZip quazip(filename);
+    bool result = true;
+    QStringList files;
+    diagnosis::ApplicationConfiguration appConfig;
+
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+    result = quazip.open(QuaZip::mdUnzip, nullptr);
+
+    if (result) {
+        // The zip archive must contain exactly two entries
+        files = quazip.getFileNameList();
+        if ((files.size() != 2) || !files.contains("export.sig") || !files.contains("export.bin")) {
+            result = false;
+        }
+    }
+
+    //TODO: Check signature file
+
+    if (result) {
+        ZipIStreamBuffer streambuf(quazip, "export.bin");
+        qDebug() << "Stream is good: " << streambuf.success();
+        std::istream stream(&streambuf);
+
+        result = appConfig.ParseFromIstream(&stream);
+    }
+
+    if (result) {
+        applyConfiguration(appConfig);
+    }
+    else {
+        qDebug() << "ApplicationConfiguration proto file failed to load";
+    }
+
+    return result;
+}
+
+void DownloadConfig::applyConfiguration(diagnosis::ApplicationConfiguration const &appConfig)
+{
+    m_configuration->setMinimumRiskScore(appConfig.minriskscore());
+    qDebug() << "Config min risk score: " << appConfig.minriskscore();
+
+    if (appConfig.has_exposureconfig()) {
+        const ::diagnosis::RiskScoreParameters& params = appConfig.exposureconfig();
+        if (params.has_transmission()) {
+            QList<qint32> transmissionRiskScores;
+            transmissionRiskScores.append(params.transmission().appdefined_1());
+            transmissionRiskScores.append(params.transmission().appdefined_2());
+            transmissionRiskScores.append(params.transmission().appdefined_3());
+            transmissionRiskScores.append(params.transmission().appdefined_4());
+            transmissionRiskScores.append(params.transmission().appdefined_5());
+            transmissionRiskScores.append(params.transmission().appdefined_6());
+            transmissionRiskScores.append(params.transmission().appdefined_7());
+            transmissionRiskScores.append(params.transmission().appdefined_8());
+            m_configuration->setTransmissionRiskScores(transmissionRiskScores);
+            qDebug() << "Config transmission risks scores:" << transmissionRiskScores;
+        }
+        m_configuration->setTransmissionRiskWeight(params.transmissionweight());
+        qDebug() << "Config transmission risk weight:" << params.transmissionweight();
+
+        if (params.has_duration()) {
+            QList<qint32> durationScores;
+            durationScores.append(params.duration().eq_0_min());
+            durationScores.append(params.duration().gt_0_le_5_min());
+            durationScores.append(params.duration().gt_5_le_10_min());
+            durationScores.append(params.duration().gt_10_le_15_min());
+            durationScores.append(params.duration().gt_15_le_20_min());
+            durationScores.append(params.duration().gt_20_le_25_min());
+            durationScores.append(params.duration().gt_25_le_30_min());
+            durationScores.append(params.duration().gt_30_min());
+            m_configuration->setDurationScores(durationScores);
+            qDebug() << "Config duration scores:" << durationScores;
+        }
+
+        m_configuration->setDurationWeight(params.durationweight());
+        qDebug() << "Config duration weight:" << params.durationweight();
+
+        if (params.has_dayssincelastexposure()) {
+            QList<qint32> daysSinceLastExposureScores;
+            daysSinceLastExposureScores.append(params.dayssincelastexposure().ge_14_days());
+            daysSinceLastExposureScores.append(params.dayssincelastexposure().ge_12_lt_14_days());
+            daysSinceLastExposureScores.append(params.dayssincelastexposure().ge_10_lt_12_days());
+            daysSinceLastExposureScores.append(params.dayssincelastexposure().ge_8_lt_10_days());
+            daysSinceLastExposureScores.append(params.dayssincelastexposure().ge_6_lt_8_days());
+            daysSinceLastExposureScores.append(params.dayssincelastexposure().ge_4_lt_6_days());
+            daysSinceLastExposureScores.append(params.dayssincelastexposure().ge_2_lt_4_days());
+            daysSinceLastExposureScores.append(params.dayssincelastexposure().ge_0_lt_2_days());
+            m_configuration->setDaysSinceLastExposureScores(daysSinceLastExposureScores);
+            qDebug() << "Config days since last exposure scores:" << daysSinceLastExposureScores;
+        }
+
+        m_configuration->setDaysSinceLastExposureWeight(params.daysweight());
+        qDebug() << "Config days weight:" << params.daysweight();
+
+        if (params.has_attenuation()) {
+            QList<qint32> attenuationScores;
+            attenuationScores.append(params.attenuation().gt_73_dbm());
+            attenuationScores.append(params.attenuation().gt_63_le_73_dbm());
+            attenuationScores.append(params.attenuation().gt_51_le_63_dbm());
+            attenuationScores.append(params.attenuation().gt_33_le_51_dbm());
+            attenuationScores.append(params.attenuation().gt_27_le_33_dbm());
+            attenuationScores.append(params.attenuation().gt_15_le_27_dbm());
+            attenuationScores.append(params.attenuation().gt_10_le_15_dbm());
+            attenuationScores.append(params.attenuation().lt_10_dbm());
+            m_configuration->setAttenuationScores(attenuationScores);
+            qDebug() << "Config attenuation scores:" << attenuationScores;
+        }
+
+        m_configuration->setAttenuationWeight(params.attenuationweight());
+        qDebug() << "Config attenuation weight:" << params.attenuationweight();
+    }
+    if (appConfig.has_attenuationduration()) {
+        const ::diagnosis::AttenuationDuration& attenuation = appConfig.attenuationduration();
+        QList<qint32> thresholds;
+        thresholds.append(attenuation.thresholds().lower());
+        thresholds.append(attenuation.thresholds().upper());
+        m_configuration->setDurationAtAttenuationThresholds(thresholds);
+        qDebug() << "Config attentuation duration thresholds:" << thresholds;
+    }
+}
+
+ExposureConfiguration const *DownloadConfig::config() const
+{
+    return m_configuration;
+}
+

--- a/src/harbour-contrac.cpp
+++ b/src/harbour-contrac.cpp
@@ -11,6 +11,7 @@
 
 #include "dbusproxy.h"
 #include "download.h"
+#include "downloadconfig.h"
 #include "upload.h"
 #include "settings.h"
 
@@ -47,6 +48,7 @@ int main(int argc, char *argv[])
     qmlRegisterType<ExposureConfiguration>("uk.co.flypig.contrac", 1, 0, "ExposureConfiguration");
     qmlRegisterType<Download>("uk.co.flypig.contrac", 1, 0, "Download");
     qmlRegisterType<Upload>("uk.co.flypig.contrac", 1, 0, "Upload");
+    qmlRegisterType<DownloadConfig>("uk.co.flypig.contrac", 1, 0, "DownloadConfig");
 
     qmlRegisterSingletonType<Settings>("uk.co.flypig.contrac", 1, 0, "Settings", Settings::provider);
 

--- a/src/harbour-contrac.cpp
+++ b/src/harbour-contrac.cpp
@@ -52,6 +52,10 @@ int main(int argc, char *argv[])
 
     qmlRegisterSingletonType<Settings>("uk.co.flypig.contrac", 1, 0, "Settings", Settings::provider);
 
+    // Needed for Settings save/load
+    qRegisterMetaType<ExposureSummary>();
+    qRegisterMetaTypeStreamOperators<ExposureSummary>("ExposureSummary");
+
     QQuickView *view = SailfishApp::createView();
     view->setSource(SailfishApp::pathTo("qml/harbour-contrac.qml"));
     QQmlContext *ctxt = view->rootContext();

--- a/src/s3access.h
+++ b/src/s3access.h
@@ -20,6 +20,7 @@ public:
 
 signals:
     void finished();
+
 protected slots:
     virtual void onFinished();
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,5 +1,7 @@
 #include <QDebug>
 
+#include "../contracd/src/exposuresummary.h"
+
 #include "settings.h"
 
 Settings * Settings::instance = nullptr;
@@ -10,6 +12,8 @@ Settings::Settings(QObject *parent) : QObject(parent),
     m_downloadServer = settings.value(QStringLiteral("servers/downloadServer"), QStringLiteral("127.0.0.1:8003")).toString();
     m_uploadServer = settings.value(QStringLiteral("servers/uploadServer"), QStringLiteral("127.0.0.1:8000")).toString();
     m_verificationServer = settings.value(QStringLiteral("servers/verificationServer"), QStringLiteral("127.0.0.1:8004")).toString();
+    m_latestSummary = settings.value(QStringLiteral("update/latestSummary"), QVariant::fromValue<ExposureSummary>(ExposureSummary())).value<ExposureSummary>();
+    m_summaryUpdated = settings.value(QStringLiteral("update/date"), QDateTime()).toDateTime();
 
     qDebug() << "Settings created: " << settings.fileName();
 }
@@ -19,6 +23,8 @@ Settings::~Settings()
     settings.setValue(QStringLiteral("servers/downloadServer"), m_downloadServer);
     settings.setValue(QStringLiteral("servers/uploadServer"), m_uploadServer);
     settings.setValue(QStringLiteral("servers/verificationServer"), m_verificationServer);
+    settings.setValue(QStringLiteral("update/latestSummary"), QVariant::fromValue<ExposureSummary>(m_latestSummary));
+    settings.setValue(QStringLiteral("update/date"), m_summaryUpdated);
 
     qDebug() << "Deleted settings";
 }
@@ -76,5 +82,31 @@ void Settings::setVerificationServer(QString const &verificationServer)
     if (m_verificationServer != verificationServer) {
         m_verificationServer = verificationServer;
         emit verificationServerChanged();
+    }
+}
+
+ExposureSummary *Settings::latestSummary()
+{
+    return &m_latestSummary;
+}
+
+void Settings::setLatestSummary(ExposureSummary const *latestSummary)
+{
+    if (m_latestSummary != *latestSummary) {
+        m_latestSummary = *latestSummary;
+        emit latestSummaryChanged();
+    }
+}
+
+QDateTime Settings::summaryUpdated() const
+{
+    return m_summaryUpdated;
+}
+
+void Settings::setSummaryUpdated(QDateTime summaryUpdated)
+{
+    if (m_summaryUpdated != summaryUpdated) {
+        m_summaryUpdated = summaryUpdated;
+        emit summaryUpdatedChanged();
     }
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -4,6 +4,9 @@
 #include <QObject>
 #include <QQmlEngine>
 #include <QSettings>
+#include <QDate>
+
+#include "../contracd/src/exposuresummary.h"
 
 class Settings : public QObject
 {
@@ -13,6 +16,8 @@ class Settings : public QObject
     Q_PROPERTY(QString downloadServer READ downloadServer WRITE setDownloadServer NOTIFY downloadServerChanged)
     Q_PROPERTY(QString uploadServer READ uploadServer WRITE setUploadServer NOTIFY uploadServerChanged)
     Q_PROPERTY(QString verificationServer READ verificationServer WRITE setVerificationServer NOTIFY verificationServerChanged)
+    Q_PROPERTY(ExposureSummary *latestSummary READ latestSummary WRITE setLatestSummary NOTIFY latestSummaryChanged)
+    Q_PROPERTY(QDateTime summaryUpdated READ summaryUpdated WRITE setSummaryUpdated NOTIFY summaryUpdatedChanged)
 
 public:
     explicit Settings(QObject *parent = nullptr);
@@ -22,20 +27,25 @@ public:
     static Settings & getInstance();
     static QObject * provider(QQmlEngine *engine, QJSEngine *scriptEngine);
 
-
     Q_INVOKABLE QString downloadServer() const;
     Q_INVOKABLE QString uploadServer() const;
     Q_INVOKABLE QString verificationServer() const;
+    Q_INVOKABLE ExposureSummary *latestSummary();
+    Q_INVOKABLE QDateTime summaryUpdated() const;
 
 signals:
     void downloadServerChanged();
     void uploadServerChanged();
     void verificationServerChanged();
+    void latestSummaryChanged();
+    void summaryUpdatedChanged();
 
 public slots:
     void setDownloadServer(QString const &downloadServer);
     void setUploadServer(QString const &uploadServer);
     void setVerificationServer(QString const &verificationServer);
+    void setLatestSummary(ExposureSummary const *latestSummary);
+    void setSummaryUpdated(QDateTime summaryUpdated);
 
 private:
     static Settings * instance;
@@ -44,6 +54,8 @@ private:
     QString m_downloadServer;
     QString m_uploadServer;
     QString m_verificationServer;
+    ExposureSummary m_latestSummary;
+    QDateTime m_summaryUpdated;
 };
 
 #endif // SETTINGS_H

--- a/tests/test_tracing.cpp
+++ b/tests/test_tracing.cpp
@@ -335,10 +335,10 @@ void Test_Tracing::testMatchAggregation()
 
     // Set up the configuration
     configuration.setMinimumRiskScore(0);
-    configuration.setAttenuationScores(QList<quint32>({0, 1, 2, 3, 4, 5, 6, 7}));
-    configuration.setDaysSinceLastExposureScores(QList<quint32>({0, 1, 2, 3, 4, 5, 6, 7}));
-    configuration.setDurationScores(QList<quint32>({0, 1, 2, 3, 4, 5, 6, 7}));
-    configuration.setTransmissionRiskScores(QList<quint32>({0, 1, 2, 3, 4, 5, 6, 7}));
+    configuration.setAttenuationScores(QList<qint32>({0, 1, 2, 3, 4, 5, 6, 7}));
+    configuration.setDaysSinceLastExposureScores(QList<qint32>({0, 1, 2, 3, 4, 5, 6, 7}));
+    configuration.setDurationScores(QList<qint32>({0, 1, 2, 3, 4, 5, 6, 7}));
+    configuration.setTransmissionRiskScores(QList<qint32>({0, 1, 2, 3, 4, 5, 6, 7}));
     configuration.setAttenuationWeight(1.0);
     configuration.setDaysSinceLastExposureWeight(1.0);
     configuration.setDurationWeight(1.0);

--- a/translations/harbour-contrac-en.ts
+++ b/translations/harbour-contrac-en.ts
@@ -55,10 +55,6 @@
         <source>BLE Contact Tracing</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-main_contact_beacons">
-        <source>Contact beacons</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-main_scan">
         <source>Scan and send active</source>
         <translation type="unfinished"></translation>
@@ -168,18 +164,6 @@
         <source>Network error</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-main_diagnosis_keys">
-        <source>Diagnosis keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="contrac-main_la_latest-upload">
-        <source>Latest upload: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="contrac-main_la_latest-download">
-        <source>Latest download: </source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-main_la_status-uploading">
         <source>Uploading</source>
         <translation type="unfinished"></translation>
@@ -192,20 +176,8 @@
         <source>Error uploading</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-main_la_status-download_err0r">
-        <source>Error downloading</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="contrac-main_la_status-no_ssues">
-        <source>No issues</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-main_bu_enter-teletan">
         <source>Enter TeleTAN</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="contrac-main_bu_download-keys">
-        <source>Download latest keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-upload_error_no-diagnosis-keys">
@@ -214,6 +186,79 @@
     </message>
     <message id="contrac-upload_error_unknown">
         <source>Unkown error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_last-update">
+        <source>Latest update</source>
+        <oldsource>Latest update:</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-download_error">
+        <source>Error downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-updating">
+        <source>Updating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_risk-status">
+        <source>Risk status</source>
+        <oldsource>Risk status:</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_days-since-last-exposure">
+        <source>Days since last exposure</source>
+        <oldsource>Days since last exposure:</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_matched-keys">
+        <source>Number of matched keys</source>
+        <oldsource>Number of matched keys: </oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-busy">
+        <source>Busy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-active">
+        <source>Active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-disabled">
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_bt_actions">
+        <source>Control</source>
+        <oldsource>Actions</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-at-rsk">
+        <source>At risk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_bu_daily-update">
+        <source>Perform daily update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_he_status">
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-download_la_completed">
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_risk-status-unknown">
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_latest-update-never">
+        <source>Never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_days-since-last-exposure-none">
+        <source>None recorded</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-contrac-zh_CN.ts
+++ b/translations/harbour-contrac-zh_CN.ts
@@ -69,10 +69,6 @@
         <oldsource>Beacons received</oldsource>
         <translation>接收</translation>
     </message>
-    <message id="contrac-main_contact_beacons">
-        <source>Contact beacons</source>
-        <translation>通讯信标</translation>
-    </message>
     <message id="contrac-settings_he_servers">
         <source>Servers</source>
         <translation type="unfinished"></translation>
@@ -170,18 +166,6 @@
         <source>Network error</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-main_diagnosis_keys">
-        <source>Diagnosis keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="contrac-main_la_latest-upload">
-        <source>Latest upload: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="contrac-main_la_latest-download">
-        <source>Latest download: </source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-main_la_status-uploading">
         <source>Uploading</source>
         <translation type="unfinished"></translation>
@@ -194,20 +178,8 @@
         <source>Error uploading</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-main_la_status-download_err0r">
-        <source>Error downloading</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="contrac-main_la_status-no_ssues">
-        <source>No issues</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-main_bu_enter-teletan">
         <source>Enter TeleTAN</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="contrac-main_bu_download-keys">
-        <source>Download latest keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-upload_error_no-diagnosis-keys">
@@ -216,6 +188,79 @@
     </message>
     <message id="contrac-upload_error_unknown">
         <source>Unkown error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_last-update">
+        <source>Latest update</source>
+        <oldsource>Latest update:</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-download_error">
+        <source>Error downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-updating">
+        <source>Updating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_risk-status">
+        <source>Risk status</source>
+        <oldsource>Risk status:</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_days-since-last-exposure">
+        <source>Days since last exposure</source>
+        <oldsource>Days since last exposure:</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_matched-keys">
+        <source>Number of matched keys</source>
+        <oldsource>Number of matched keys: </oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-busy">
+        <source>Busy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-active">
+        <source>Active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-disabled">
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_bt_actions">
+        <source>Control</source>
+        <oldsource>Actions</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-at-rsk">
+        <source>At risk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_bu_daily-update">
+        <source>Perform daily update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_he_status">
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-download_la_completed">
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_risk-status-unknown">
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_latest-update-never">
+        <source>Never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_days-since-last-exposure-none">
+        <source>None recorded</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-contrac.ts
+++ b/translations/harbour-contrac.ts
@@ -55,10 +55,6 @@
         <source>BLE Contact Tracing</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-main_contact_beacons">
-        <source>Contact beacons</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-main_scan">
         <source>Scan and send active</source>
         <translation type="unfinished"></translation>
@@ -168,18 +164,6 @@
         <source>Network error</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-main_diagnosis_keys">
-        <source>Diagnosis keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="contrac-main_la_latest-upload">
-        <source>Latest upload: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="contrac-main_la_latest-download">
-        <source>Latest download: </source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-main_la_status-uploading">
         <source>Uploading</source>
         <translation type="unfinished"></translation>
@@ -192,20 +176,8 @@
         <source>Error uploading</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-main_la_status-download_err0r">
-        <source>Error downloading</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="contrac-main_la_status-no_ssues">
-        <source>No issues</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-main_bu_enter-teletan">
         <source>Enter TeleTAN</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="contrac-main_bu_download-keys">
-        <source>Download latest keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="contrac-upload_error_no-diagnosis-keys">
@@ -214,6 +186,79 @@
     </message>
     <message id="contrac-upload_error_unknown">
         <source>Unkown error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_last-update">
+        <source>Latest update</source>
+        <oldsource>Latest update:</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-download_error">
+        <source>Error downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-updating">
+        <source>Updating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_risk-status">
+        <source>Risk status</source>
+        <oldsource>Risk status:</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_days-since-last-exposure">
+        <source>Days since last exposure</source>
+        <oldsource>Days since last exposure:</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_matched-keys">
+        <source>Number of matched keys</source>
+        <oldsource>Number of matched keys: </oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-busy">
+        <source>Busy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-active">
+        <source>Active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-disabled">
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_bt_actions">
+        <source>Control</source>
+        <oldsource>Actions</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_status-at-rsk">
+        <source>At risk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_bu_daily-update">
+        <source>Perform daily update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_he_status">
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-download_la_completed">
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_risk-status-unknown">
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_latest-update-never">
+        <source>Never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_la_days-since-last-exposure-none">
+        <source>None recorded</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
The ExposureConfiguration structure needs to be filled out with values
in order for the risk calculations to be applied correctly.

This change adds a step which downloads the configuration values from
the download server in proto format, extracts the relevant values and
returns them in an ExposureConfiguration structure which can be passed
to the Contrac daemon.

Fixes #13.