### PR TITLE
WIP: Set build configuration for sfdk 3.3.0

### DIFF
--- a/contrac.pro
+++ b/contrac.pro
@@ -117,12 +117,13 @@ PKGCONFIG += \
     libxml-2.0 \
     libcurl \
     keepalive \
-    protobuf-lite \
-    quazip
+    protobuf-lite
 
 DEFINES += LINUX
 
 QT += dbus
+
+LIBS += -lquazip
 
 OTHER_FILES += \
     src/submissionpayload.proto \

--- a/contracd/contracd.pro
+++ b/contracd/contracd.pro
@@ -80,10 +80,11 @@ DISTFILES += \
 
 PKGCONFIG += \
     openssl \
-    protobuf-lite \
-    quazip
+    protobuf-lite
 
 QT += dbus
+
+LIBS += -lquazip
 
 OTHER_FILES += \
     src/contrac.proto

--- a/contracd/src/zipistreambuffer.h
+++ b/contracd/src/zipistreambuffer.h
@@ -1,8 +1,8 @@
 #ifndef ZIPISTREAMBUFFER_H
 #define ZIPISTREAMBUFFER_H
 
-#include <quazip5/quazip.h>
-#include <quazip5/quazipfile.h>
+#include <quazip/quazip.h>
+#include <quazip/quazipfile.h>
 
 #include <iostream>
 

--- a/rpm/harbour-contrac.spec
+++ b/rpm/harbour-contrac.spec
@@ -24,9 +24,9 @@ BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(protobuf-lite)
 BuildRequires:  pkgconfig(libcurl)
 BuildRequires:  pkgconfig(libxml-2.0)
-BuildRequires:  pkgconfig(quazip)
 BuildRequires:  pkgconfig(keepalive)
 BuildRequires:  protobuf-compiler
+BuildRequires:  quazip-devel
 BuildRequires:  desktop-file-utils
 
 %description

--- a/rpm/harbour-contrac.yaml
+++ b/rpm/harbour-contrac.yaml
@@ -28,12 +28,12 @@ PkgConfigBR:
   - protobuf-lite
   - libcurl
   - libxml-2.0
-  - quazip
   - keepalive
 
 # Build dependencies without a pkgconfig setup can be listed here
 PkgBR:
   - protobuf-compiler
+  - quazip-devel
 
 # Runtime dependencies which are not automatically detected
 Requires:

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -25,8 +25,9 @@ INCLUDEPATH += ../src/ ./mock/
 PKGCONFIG += \
     mlite5 \
     openssl \
-    protobuf-lite \
-    quazip
+    protobuf-lite
+
+LIBS += -lquazip
 
 SOURCES += \
     test_tracing.cpp


### PR DESCRIPTION
Changes needed to get the project to build on the Application SDK 3.3.0.

This isn't intended to be merged, but the commit can be added/removed as needed for building on the Application SDK 3.3.0.