### PR TITLE
Support in-app attenuation variable configuration

### DIFF
--- a/contracd/src/dbusinterface.h
+++ b/contracd/src/dbusinterface.h
@@ -22,6 +22,8 @@ class DBusInterface : public QObject
     Q_PROPERTY(quint32 receivedCount READ receivedCount NOTIFY receivedCountChanged)
     Q_PROPERTY(quint32 sentCount READ sentCount NOTIFY sentCountChanged)
     Q_PROPERTY(bool isBusy READ isBusy NOTIFY isBusyChanged)
+    Q_PROPERTY(qint32 txPower READ txPower WRITE setTxPower NOTIFY txPowerChanged)
+    Q_PROPERTY(qint32 rssiCorrection READ rssiCorrection WRITE setRssiCorrection NOTIFY rssiCorrectionChanged)
 
 public:
     explicit DBusInterface(QObject *parent = nullptr);
@@ -44,6 +46,10 @@ public:
     Q_INVOKABLE quint32 receivedCount() const;
     Q_INVOKABLE quint32 sentCount() const;
     Q_INVOKABLE bool isBusy() const;
+    Q_INVOKABLE qint32 txPower() const;
+    Q_INVOKABLE qint32 rssiCorrection() const;
+    Q_INVOKABLE void setTxPower(qint32 txPower);
+    Q_INVOKABLE void setRssiCorrection(qint32 rssiCorrection);
 
 signals:
     void statusChanged();
@@ -53,6 +59,8 @@ signals:
     void receivedCountChanged();
     void sentCountChanged();
     void isBusyChanged();
+    void txPowerChanged();
+    void rssiCorrectionChanged();
 
 public slots:
 

--- a/qml/pages/Main.qml
+++ b/qml/pages/Main.qml
@@ -6,6 +6,7 @@ import uk.co.flypig.contrac 1.0
 Page {
     id: page
     property string token: "abcdef"
+    property alias dbusproxy: dbusproxy
     property alias upload: upload
     property alias download: download
     property bool updating
@@ -108,7 +109,7 @@ Page {
             MenuItem {
                 //% "Settings"
                 text: qsTrId("contrac-main_settings")
-                onClicked: pageStack.push(Qt.resolvedUrl("Settings.qml"))
+                onClicked: pageStack.push(Qt.resolvedUrl("Settings.qml"), {dbusproxy: page.dbusproxy})
             }
         }
 

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -5,10 +5,13 @@ import uk.co.flypig.contrac 1.0
 
 Page {
     id: settingsPage
+    property DBusProxy dbusproxy
 
     Binding { target: Settings; property: "downloadServer"; value: downloadServerEntry.text }
     Binding { target: Settings; property: "uploadServer"; value: uploadServerEntry.text }
     Binding { target: Settings; property: "verificationServer"; value: verificationServerEntry.text }
+    Binding { target: dbusproxy; property: "txPower"; value: txPowerEntry.text }
+    Binding { target: dbusproxy; property: "rssiCorrection"; value: rssiCorrectionEntry.text }
 
     allowedOrientations: Orientation.All
 
@@ -25,8 +28,13 @@ Page {
             spacing: Theme.paddingLarge
 
             PageHeader {
+                //% "Settings"
+                title: qsTrId("contrac-settings_he_settings")
+            }
+
+            SectionHeader {
                 //% "Servers"
-                title: qsTrId("contrac-settings_he_servers")
+                text: qsTrId("contrac-settings_he_servers")
             }
 
             TextField {
@@ -38,7 +46,7 @@ Page {
                 text: Settings.downloadServer
                 inputMethodHints: Qt.ImhUrlCharactersOnly | Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
-                EnterKey.onClicked: uploadServer.focus = true
+                EnterKey.onClicked: uploadServerEntry.focus = true
             }
 
             TextField {
@@ -50,7 +58,7 @@ Page {
                 text: Settings.uploadServer
                 inputMethodHints: Qt.ImhUrlCharactersOnly | Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
-                EnterKey.onClicked: verificationServer.focus = true
+                EnterKey.onClicked: verificationServerEntry.focus = true
             }
 
             TextField {
@@ -61,8 +69,53 @@ Page {
                 width: parent.width
                 text: Settings.verificationServer
                 inputMethodHints: Qt.ImhUrlCharactersOnly | Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
+                EnterKey.iconSource: "image://theme/icon-m-enter-next"
+                EnterKey.onClicked: txPowerEntry.focus = true
+            }
+
+            SectionHeader {
+                //% "Attenuation calibration"
+                text: qsTrId("contrac-settings_he_attentuation-values")
+            }
+
+            TextField {
+                id: txPowerEntry
+                //% "Transmit power"
+                label: qsTrId("contrac-settings_tf_transmit-power")
+                placeholderText: label
+                width: parent.width
+                text: dbusproxy.txPower
+                inputMethodHints: Qt.ImhDigitsOnly
+                EnterKey.iconSource: "image://theme/icon-m-enter-next"
+                EnterKey.onClicked: rssiCorrectionEntry.focus = true
+            }
+
+            TextField {
+                id: rssiCorrectionEntry
+                //% "RSSI correction"
+                label: qsTrId("contrac-settings_tf_rssi-correction")
+                placeholderText: label
+                width: parent.width
+                text: dbusproxy.rssiCorrection
+                inputMethodHints: Qt.ImhDigitsOnly
                 //EnterKey.iconSource: "image://theme/icon-m-enter-next"
-                //EnterKey.onClicked: uploadUrl.focus = true
+                //EnterKey.onClicked: Entry.focus = true
+            }
+
+            Label {
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                x: Theme.horizontalPageMargin
+                color: Theme.highlightColor
+                wrapMode: Text.Wrap
+                //% "Download the calibration spreadsheet to check the attenuation values for your device."
+                text: qsTrId("contrac-settings_la_attenuation_info")
+            }
+
+            Button {
+                anchors.horizontalCenter: parent.horizontalCenter
+                //% "Download"
+                text: qsTrId("contrac-settings_bu_download_attenuation_spreadsheet")
+                onClicked: Qt.openUrlExternally("https://developers.google.com/android/exposure-notifications/files/en-calibration-2020-08-12.csv")
             }
         }
     }

--- a/src/dbusproxy.cpp
+++ b/src/dbusproxy.cpp
@@ -42,6 +42,12 @@ DBusProxy::DBusProxy(QObject *parent)
 
     result = QDBusConnection::sessionBus().connect("uk.co.flypig.contrac", "/", "uk.co.flypig.contrac", "isBusyChanged", argumentMatch, signature, this, SIGNAL(isBusyChanged()));
     qDebug() << "Connection isBusyChanged result: " << result;
+
+    result = QDBusConnection::sessionBus().connect("uk.co.flypig.contrac", "/", "uk.co.flypig.contrac", "txPowerChanged", argumentMatch, signature, this, SIGNAL(txPowerChanged()));
+    qDebug() << "Connection txPowerChanged result: " << result;
+
+    result = QDBusConnection::sessionBus().connect("uk.co.flypig.contrac", "/", "uk.co.flypig.contrac", "rssiCorrectionChanged", argumentMatch, signature, this, SIGNAL(rssiCorrectionChanged()));
+    qDebug() << "Connection rssiCorrectionChanged result: " << result;
 }
 
 DBusProxy::~DBusProxy()
@@ -194,3 +200,30 @@ QList<ExposureInformation> *DBusProxy::getExposureInformation(QString const &tok
     return result;
 }
 
+qint32 DBusProxy::txPower() const
+{
+    QDBusReply<qint32> reply = m_interface->call("txPower");
+    return reply;
+}
+
+void DBusProxy::setTxPower(qint32 txPower)
+{
+    QDBusMessage reply = m_interface->call("setTxPower", txPower);
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        qDebug() << "DBus error setting txPower: " << reply.errorMessage();
+    }
+}
+
+qint32 DBusProxy::rssiCorrection() const
+{
+    QDBusReply<qint32> reply = m_interface->call("rssiCorrection");
+    return reply;
+}
+
+void DBusProxy::setRssiCorrection(qint32 rssiCorrection)
+{
+    QDBusMessage reply = m_interface->call("setRssiCorrection", rssiCorrection);
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        qDebug() << "DBus error setting rssiCorrection: " << reply.errorMessage();
+    }
+}

--- a/src/dbusproxy.h
+++ b/src/dbusproxy.h
@@ -26,6 +26,9 @@ class DBusProxy : public QObject
     Q_PROPERTY(quint32 receivedCount READ receivedCount NOTIFY receivedCountChanged)
     Q_PROPERTY(quint32 sentCount READ sentCount NOTIFY sentCountChanged)
     Q_PROPERTY(bool isBusy READ isBusy NOTIFY isBusyChanged)
+    Q_PROPERTY(qint32 txPower READ txPower WRITE setTxPower NOTIFY txPowerChanged)
+    Q_PROPERTY(qint32 rssiCorrection READ rssiCorrection WRITE setRssiCorrection NOTIFY rssiCorrectionChanged)
+
 public:
     explicit DBusProxy(QObject *parent = nullptr);
     ~DBusProxy();
@@ -57,6 +60,10 @@ public:
     quint32 receivedCount() const;
     quint32 sentCount() const;
     bool isBusy() const;
+    qint32 txPower() const;
+    qint32 rssiCorrection() const;
+    void setTxPower(qint32 txPower);
+    void setRssiCorrection(qint32 rssiCorrection);
 
 signals:
     void statusChanged();
@@ -66,6 +73,8 @@ signals:
     void receivedCountChanged();
     void sentCountChanged();
     void isBusyChanged();
+    void txPowerChanged();
+    void rssiCorrectionChanged();
 
     // Async responses
     void provideDiagnosisKeysResult(Status status, QString const &token);

--- a/translations/harbour-contrac-en.ts
+++ b/translations/harbour-contrac-en.ts
@@ -261,5 +261,30 @@
         <source>None recorded</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="contrac-settings_tf_transmit-power">
+        <source>Transmit power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_tf_rssi-correction">
+        <source>RSSI correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_he_settings">
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_he_attentuation-values">
+        <source>Attenuation calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_la_attenuation_info">
+        <source>Download the calibration spreadsheet to check the attenuation values for your device.</source>
+        <oldsource>Download the spreadsheet to check the attenuation calibration values for your device</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_bu_download_attenuation_spreadsheet">
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/harbour-contrac-zh_CN.ts
+++ b/translations/harbour-contrac-zh_CN.ts
@@ -263,5 +263,30 @@
         <source>None recorded</source>
         <translation>暂无记录</translation>
     </message>
+    <message id="contrac-settings_tf_transmit-power">
+        <source>Transmit power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_tf_rssi-correction">
+        <source>RSSI correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_he_settings">
+        <source>Settings</source>
+        <translation type="unfinished">设置</translation>
+    </message>
+    <message id="contrac-settings_he_attentuation-values">
+        <source>Attenuation calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_la_attenuation_info">
+        <source>Download the calibration spreadsheet to check the attenuation values for your device.</source>
+        <oldsource>Download the spreadsheet to check the attenuation calibration values for your device</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_bu_download_attenuation_spreadsheet">
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/harbour-contrac.ts
+++ b/translations/harbour-contrac.ts
@@ -261,5 +261,30 @@
         <source>None recorded</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="contrac-settings_tf_transmit-power">
+        <source>Transmit power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_tf_rssi-correction">
+        <source>RSSI correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_he_settings">
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_he_attentuation-values">
+        <source>Attenuation calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_la_attenuation_info">
+        <source>Download the calibration spreadsheet to check the attenuation values for your device.</source>
+        <oldsource>Download the spreadsheet to check the attenuation calibration values for your device</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_bu_download_attenuation_spreadsheet">
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>


### PR DESCRIPTION
The transmit power and rssi correction values are determined
experimentally based on the device in use. The values live in the
daemon, but this change allows them to be configured via the dbus
interface and the app UI.

See here for more info about the values:

https://developers.google.com/android/exposure-notifications/ble-attenuation-overview

The experimentally-determined attentuation values for various devices
can be got from here:

https://developers.google.com/android/exposure-notifications/files/en-calibration-2020-08-12.csv