### PR TITLE
German locale

### DIFF
--- a/translations/harbour-contrac-de.ts
+++ b/translations/harbour-contrac-de.ts
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name></name>
+    <message id="contrac-about_title">
+        <source>About Contrac</source>
+        <oldsource>About Contact Tracer</oldsource>
+        <translation>Über Contrac</translation>
+    </message>
+    <message id="contrac-about_description">
+        <source>Corona-Warn-App compatible contact Tracing using the Apple/Google Exposure Notification API</source>
+        <oldsource>Demonstration of the Apple/Google Contract Tracing API</oldsource>
+        <translation>Corona-Warn-App-kompatible Kontaktverfolgung unter Nutzung der Apple/Google Exposure Notification-API</translation>
+    </message>
+    <message id="contrac-about_verion">
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message id="contrac-about_licence">
+        <source>Licence</source>
+        <translation>Lizenz</translation>
+    </message>
+    <message id="contrac-about_gpl_v2">
+        <source>GPLv2</source>
+        <translation>GPLv2</translation>
+    </message>
+    <message id="contrac-about_header_links">
+        <source>Links</source>
+        <translation>Links</translation>
+    </message>
+    <message id="contrac-about_website">
+        <source>Website</source>
+        <translation>Webseite</translation>
+    </message>
+    <message id="contrac-about_email">
+        <source>Email</source>
+        <translation>E-Mail</translation>
+    </message>
+    <message id="contrac-main_about">
+        <source>About</source>
+        <translation>Über</translation>
+    </message>
+    <message id="contrac-main_title">
+        <source>Contrac Exposure Notification</source>
+        <oldsource>BLE Contact Tracing</oldsource>
+        <translation>Contrac Kontakt-Benachrichtigung</translation>
+    </message>
+    <message id="contrac-main_scan">
+        <source>Scan and send active</source>
+        <oldsource>Scan and transmit</oldsource>
+        <translation>Scannen und Senden aktiv</translation>
+    </message>
+    <message id="contrac-main_sent">
+        <source>Sent</source>
+        <translation>Gesendet</translation>
+    </message>
+    <message id="contrac-main_received">
+        <source>Received</source>
+        <oldsource>Beacons received</oldsource>
+        <translation>Empfangen</translation>
+    </message>
+    <message id="contrac-settings_he_servers">
+        <source>Servers</source>
+        <translation>Server</translation>
+    </message>
+    <message id="contrac-settings_tf_download_server">
+        <source>Download server</source>
+        <translation>Download-Server</translation>
+    </message>
+    <message id="contrac-main_settings">
+        <source>Settings</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message id="contrac-settings_tf_upload_server">
+        <source>Upload server</source>
+        <translation>Upload-Server</translation>
+    </message>
+    <message id="contrac-settings_tf_verification_server">
+        <source>Verification server</source>
+        <translation>Verifizierungs-Server</translation>
+    </message>
+    <message id="contrac-main_info">
+        <source>Using the Google/Apple API and a Corona Warn App test server. Uploads/downloads are only for testing.</source>
+        <oldsource>Using the Google/Apple API and a Corona Warn App test server. Uploads/downloads are only for testing</oldsource>
+        <translation>Nutzung der Google/Apple-API und eines Corona-Warn-App-Testservers. Uploads/Downloads sind nur zum Testen.</translation>
+    </message>
+    <message id="contrac-teletan_he_tan_entry">
+        <source>TAN entry</source>
+        <translation>TAN-Eingabe</translation>
+    </message>
+    <message id="contrac-teletan_instructions">
+        <source>Please enter the 10-digit TAN that you were given.</source>
+        <translation>Bitte geben Sie die 10-stellige TAN ein, die Sie erhalten haben.</translation>
+    </message>
+    <message id="contrac-upload_he_uploading">
+        <source>Uploading</source>
+        <translation>Lädt hoch...</translation>
+    </message>
+    <message id="contrac-upload_instructions">
+        <source>Please wait while your keys are uploaded.</source>
+        <translation>Bitte warten Sie, während Ihre Schlüssel hochgeladen werden.</translation>
+    </message>
+    <message id="contrac-upload_error_invalid-tan">
+        <source>Error: Invalid TAN</source>
+        <translation>Fehler: ungültige TAN</translation>
+    </message>
+    <message id="contrac-upload_error_invalid-reg-token">
+        <source>Error: Invalid registration token</source>
+        <translation>Fehler: ungültiger Registrierungs-Token</translation>
+    </message>
+    <message id="contrac-upload_error_invalid-diagnosis-keys">
+        <source>Error: Invalid diagnosis keys</source>
+        <translation>Fehler: ungültige Diagnose-Schlüssel</translation>
+    </message>
+    <message id="contrac-upload_error_parsing">
+        <source>Error parsing reply from server</source>
+        <translation>Fehler beim Verarbeiten der Server-Antwort</translation>
+    </message>
+    <message id="contrac-upload_error_internal-state">
+        <source>Internal state error</source>
+        <translation>Interner Status-Fehler</translation>
+    </message>
+    <message id="contrac-upload_error_none">
+        <source>No error</source>
+        <translation>Ohne Fehler</translation>
+    </message>
+    <message id="contrac-teletan_invalid-character">
+        <source>Invalid entry. Please check your entry.</source>
+        <translation>Ungültiger Eintrag, bitte überprüfen Sie diesen.</translation>
+    </message>
+    <message id="contrac-teletan_invalid-tan">
+        <source>Invalid TAN, please check your entry.</source>
+        <translation>Ungültige TAN, bitte überprüfen Sie diese.</translation>
+    </message>
+    <message id="contrac-teletan_describe-valid-tans">
+        <source>The only TANs the test server accepts are R3ZNUEV9JA and CG4Z5A9CY9.</source>
+        <translation>Die einzigen TANs, die der Test-Server akzeptiert, sind R3ZNUEV9JA und CG4Z5A9CY9.</translation>
+    </message>
+    <message id="contrac-download_error_network-error">
+        <source>Network error</source>
+        <translation>Netzwerkfehler</translation>
+    </message>
+    <message id="contrac-download_error_none">
+        <source>No error</source>
+        <translation>Ohne Fehler</translation>
+    </message>
+    <message id="contrac-download_he_downloading">
+        <source>Downloading</source>
+        <translation>Lädt herunter...</translation>
+    </message>
+    <message id="contrac-download_instructions">
+        <source>Please wait while keys are downloaded.</source>
+        <translation>Bitte warten Sie, während die Schlüssel heruntergeladen werden.</translation>
+    </message>
+    <message id="contrac-upload_error_network-error">
+        <source>Network error</source>
+        <translation>Netzwerkfehler</translation>
+    </message>
+    <message id="contrac-main_la_status-uploading">
+        <source>Uploading</source>
+        <translation>Lädt hoch...</translation>
+    </message>
+    <message id="contrac-main_la_status-downloading">
+        <source>Downloading</source>
+        <translation>Lädt herunter...</translation>
+    </message>
+    <message id="contrac-main_la_status-upload_error">
+        <source>Error uploading</source>
+        <translation>Fehler beim Hochladen</translation>
+    </message>
+    <message id="contrac-main_bu_enter-teletan">
+        <source>Enter TeleTAN</source>
+        <translation>TeleTAN eingeben</translation>
+    </message>
+    <message id="contrac-upload_error_no-diagnosis-keys">
+        <source>Error: No diagnosis keys to upload</source>
+        <translation>Fehler: keine Diagnose-Schlüssel zum Hochladen</translation>
+    </message>
+    <message id="contrac-upload_error_unknown">
+        <source>Unknown error</source>
+        <translation>Unbekannter Fehler</translation>
+    </message>
+    <message id="contrac-main_la_last-update">
+        <source>Latest update</source>
+        <oldsource>Latest update:</oldsource>
+        <translation>Letzte Aktualisierung</translation>
+    </message>
+    <message id="contrac-main_la_status-download_error">
+        <source>Error downloading</source>
+        <translation>Fehler beim Herunterladen</translation>
+    </message>
+    <message id="contrac-main_la_status-updating">
+        <source>Updating</source>
+        <translation>Aktualisiere...</translation>
+    </message>
+    <message id="contrac-main_la_risk-status">
+        <source>Risk status</source>
+        <oldsource>Risk status:</oldsource>
+        <translation>Risiko-Status</translation>
+    </message>
+    <message id="contrac-main_la_days-since-last-exposure">
+        <source>Days since last exposure</source>
+        <oldsource>Days since last exposure:</oldsource>
+        <translation>Tage seit dem letzten Kontakt</translation>
+    </message>
+    <message id="contrac-main_la_matched-keys">
+        <source>Number of matched keys</source>
+        <oldsource>Number of matched keys: </oldsource>
+        <translation>Zahl der gematchten Schlüssel</translation>
+    </message>
+    <message id="contrac-main_la_status-busy">
+        <source>Busy</source>
+        <translation>Beschäftigt</translation>
+    </message>
+    <message id="contrac-main_la_status-active">
+        <source>Active</source>
+        <translation>Aktiv</translation>
+    </message>
+    <message id="contrac-main_la_status-disabled">
+        <source>Disabled</source>
+        <translation>Deaktiviert</translation>
+    </message>
+    <message id="contrac-main_bt_actions">
+        <source>Control</source>
+        <oldsource>Actions</oldsource>
+        <translation>Steuerung</translation>
+    </message>
+    <message id="contrac-main_bu_daily-update">
+        <source>Perform daily update</source>
+        <translation>Tägliche Aktualisierung durchführen</translation>
+    </message>
+    <message id="contrac-main_he_status">
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message id="contrac-download_la_completed">
+        <source>Completed</source>
+        <translation>Abgeschlossen</translation>
+    </message>
+    <message id="contrac-main_la_risk-status-unknown">
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+    <message id="contrac-main_la_latest-update-never">
+        <source>Never</source>
+        <translation>Nie</translation>
+    </message>
+    <message id="contrac-main_la_days-since-last-exposure-none">
+        <source>None recorded</source>
+        <translation>Keine aufgezeichnet</translation>
+    </message>
+    <message id="contrac-settings_tf_transmit-power">
+        <source>Transmit power</source>
+        <translation>Übertragungsstärke</translation>
+    </message>
+    <message id="contrac-settings_tf_rssi-correction">
+        <source>RSSI correction</source>
+        <translation>RSSI-Korrektur</translation>
+    </message>
+    <message id="contrac-settings_he_settings">
+        <source>Settings</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message id="contrac-settings_he_attentuation-values">
+        <source>Attenuation calibration</source>
+        <translation>Dämpfungs-Kalibrierung</translation>
+    </message>
+    <message id="contrac-settings_la_attenuation_info">
+        <source>Download the calibration spreadsheet to check the attenuation values for your device.</source>
+        <oldsource>Download the spreadsheet to check the attenuation calibration values for your device</oldsource>
+        <translation>Laden Sie die Kalibrierungstabelle herunter, um die Dämpfungs-Kalibrierungsvariablen für Ihr Gerät zu prüfen.</translation>
+    </message>
+    <message id="contrac-settings_bu_download_attenuation_spreadsheet">
+        <source>Download</source>
+        <translation>Herunterladen</translation>
+    </message>
+    <message id="contrac-about_he_contributors">
+        <source>Contributors</source>
+        <translation>Mitwirkende</translation>
+    </message>
+    <message id="contrac-about_la_contributors">
+        <source>ApostolosB, dashinfantry, flypig, smdesai, Thaodan</source>
+        <oldsource>Contributors: ApostolosB, dashinfantry, flypig, smdesai, Thaodan</oldsource>
+        <translation>ApostolosB, dashinfantry, flypig, smdesai, spodermenpls, Thaodan</translation>
+    </message>
+    <message id="contrac-cover_la_title">
+        <source>Contrac</source>
+        <translation>Contrac</translation>
+    </message>
+    <message id="contrac-cover_current-status-line1">
+        <source>Current</source>
+        <translation>Gegenwärtiger</translation>
+    </message>
+    <message id="contrac-cover_current-status-line2">
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message id="contrac-main_la_status-daily-update-required">
+        <source>At risk</source>
+        <translation>Gefährdet</translation>
+    </message>
+    <message id="contrac-main_la_status-at-risk">
+        <source>Daily update required</source>
+        <translation>Tägliche Aktualisierung benötigt</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Now that the dust among the locale strings has settled, I've prepared my promised German locale. I hope it meets your standards.

Unfortunately, I'll probably never see the translation in action for myself, since there's no support for my Jolla 1 (as discussed), but the other German-speaking Sailfish users with newer devices may enjoy the native language support, nevertheless. 😄

While translating, I've noticed some errors you may want to correct (I've only corrected them in my file, not the others):
- in all 4 files, "contrac-main_info" has 2 source lines, the "new" one is a duplicate of the old one, though and seems unnecessary (edit: I've seen now that the string is about to be deleted, so that's taken care of anyway)
- there are two lines with "invald" (invalid) and one line with "unkown" (unknown) in the older locale files
- the Chinese locale maintainer accidentally (?) inserted a Chinese symbol in the "[...]calibration**入**" source string
- the Chinese translation of "Current" was placed inside the beginning `<translation>` tag, not after