### PR TITLE
Add combined risk score calculation

### DIFF
--- a/contrac.pro
+++ b/contrac.pro
@@ -44,6 +44,7 @@ CONFIG += sailfishapp
 HEADERS += \
     proto/submissionpayload.pb.h \
     proto/applicationConfiguration.pb.h \
+    src/appsettings.h \
     src/dbusproxy.h \
     src/contactmodel.h \
     src/download.h \
@@ -57,12 +58,12 @@ HEADERS += \
     src/riskscoreclass.h \
     src/riskstatus.h \
     src/serveraccess.h \
-    src/settings.h \
     src/upload.h
 
 SOURCES += \
     proto/submissionpayload.pb.cc \
     proto/applicationConfiguration.pb.cc \
+    src/appsettings.cpp \
     src/downloadconfig.cpp \
     src/harbour-contrac.cpp \
     src/dbusproxy.cpp \
@@ -77,7 +78,6 @@ SOURCES += \
     src/riskscoreclass.cpp \
     src/riskstatus.cpp \
     src/serveraccess.cpp \
-    src/settings.cpp \
     src/upload.cpp
 
 DISTFILES += \

--- a/contrac.pro
+++ b/contrac.pro
@@ -54,6 +54,8 @@ HEADERS += \
     contracd/src/temporaryexposurekey.h \
     contracd/src/exposureconfiguration.h \
     contracd/src/zipistreambuffer.h \
+    src/riskscoreclass.h \
+    src/riskstatus.h \
     src/serveraccess.h \
     src/settings.h \
     src/upload.h
@@ -72,6 +74,8 @@ SOURCES += \
     contracd/src/temporaryexposurekey.cpp \
     contracd/src/exposureconfiguration.cpp \
     contracd/src/zipistreambuffer.cpp \
+    src/riskscoreclass.cpp \
+    src/riskstatus.cpp \
     src/serveraccess.cpp \
     src/settings.cpp \
     src/upload.cpp

--- a/contracd/src/exposureconfiguration.cpp
+++ b/contracd/src/exposureconfiguration.cpp
@@ -11,7 +11,6 @@ ExposureConfiguration::ExposureConfiguration(QObject *parent)
     , m_daysSinceLastExposureWeight(1.0)
     , m_durationWeight(1.0)
     , m_transmissionRiskWeight(1.0)
-    , m_durationAtAttenuationThresholds({8, 64})
 {
 }
 

--- a/contracd/src/exposurenotification.cpp
+++ b/contracd/src/exposurenotification.cpp
@@ -474,7 +474,7 @@ ExposureSummary ExposureNotification::getExposureSummary(QString const &token) c
     QList<ExposureInformation> exposureInfoList;
     ExposureSummary summary;
     quint64 mostRecent;
-    quint32 day;
+    quint32 daysAgo;
     qint32 maxRiskScore;
     qint32 summationRiskScore;
     QList<qint32> attenuationDurations = QList<qint32>({0, 0, 0});
@@ -498,10 +498,16 @@ ExposureSummary ExposureNotification::getExposureSummary(QString const &token) c
 
             summationRiskScore += exposure.totalRiskScore();
         }
-        day = static_cast<quint32>(mostRecent / (24 * 60 * 60 * 1000));
-        day += 12;
 
-        summary.setDaysSinceLastExposure(day);
+        if (mostRecent == 0) {
+            daysAgo = 0;
+        }
+        else {
+            qint64 daysDelta = (QDateTime::currentMSecsSinceEpoch() - qint64(mostRecent)) / (24 * 60 * 60 * 1000);
+            daysAgo = quint32(daysDelta);
+        }
+
+        summary.setDaysSinceLastExposure(daysAgo);
         summary.setMatchedKeyCount(static_cast<quint32>(exposureInfoList.count()));
         summary.setMaximumRiskScore(maxRiskScore);
         summary.setAttenuationDurations(attenuationDurations);

--- a/contracd/src/exposuresummary.h
+++ b/contracd/src/exposuresummary.h
@@ -12,6 +12,7 @@ class ExposureSummary : public QObject
     Q_PROPERTY(qint32 maximumRiskScore READ maximumRiskScore WRITE setMaximumRiskScore NOTIFY maximumRiskScoreChanged)
     Q_PROPERTY(QList<qint32> attenuationDurations READ attenuationDurations WRITE setAttenuationDurations NOTIFY attenuationDurationsChanged)
     Q_PROPERTY(qint32 summationRiskScore READ summationRiskScore WRITE setSummationRiskScore NOTIFY summationRiskScoreChanged)
+
 public:
     explicit ExposureSummary(QObject *parent = nullptr);
     ExposureSummary(ExposureSummary const &exposureSummary);

--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -47,7 +47,7 @@ CoverBackground {
                 return Qt.resolvedUrl("image://contrac/cover-warning")
             } else if (download.status === Download.StatusError) {
                 return Qt.resolvedUrl("image://contrac/cover-warning")
-            } else if (Settings.latestSummary.summationRiskScore >= 15) {
+            } else if (riskStatus.riskClassIndex > 0) {
                 return Qt.resolvedUrl("image://contrac/cover-warning")
             } else if (downloadAvailable) {
                 return Qt.resolvedUrl("image://contrac/cover-unknown")

--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -102,7 +102,7 @@ CoverBackground {
         enabled: downloadAvailable && !busy
 
         CoverAction {
-            iconSource: dbusproxy.isEnabled ? Settings.getImageUrl("cover-action-active") : Settings.getImageUrl("cover-action-inactive")
+            iconSource: dbusproxy.isEnabled ? AppSettings.getImageUrl("cover-action-active") : AppSettings.getImageUrl("cover-action-inactive")
             onTriggered: triggerEnabled()
         }
 
@@ -117,7 +117,7 @@ CoverBackground {
         enabled: !coverActionWithDownload.enabled
 
         CoverAction {
-            iconSource: dbusproxy.isEnabled ? Settings.getImageUrl("cover-action-active") : Settings.getImageUrl("cover-action-inactive")
+            iconSource: dbusproxy.isEnabled ? AppSettings.getImageUrl("cover-action-active") : AppSettings.getImageUrl("cover-action-inactive")
             onTriggered: triggerEnabled()
         }
     }

--- a/qml/harbour-contrac.qml
+++ b/qml/harbour-contrac.qml
@@ -27,6 +27,10 @@ ApplicationWindow
         updateFrequency: WallClock.Day
     }
 
+    RiskStatus {
+        id: riskStatus
+    }
+
     function moreThanADayAgo(latest) {
         var result = true
         if (!isNaN(latest)) {

--- a/qml/harbour-contrac.qml
+++ b/qml/harbour-contrac.qml
@@ -6,7 +6,7 @@ import "pages"
 
 ApplicationWindow
 {
-    readonly property bool downloadAvailable: moreThanADayAgo(Settings.summaryUpdated)
+    readonly property bool downloadAvailable: moreThanADayAgo(AppSettings.summaryUpdated)
     property bool updating
     readonly property bool busy: upload.uploaindg || download.downloading || updating || dbusproxy.isBusy
 

--- a/qml/pages/Main.qml
+++ b/qml/pages/Main.qml
@@ -9,14 +9,6 @@ Page {
 
     allowedOrientations: Orientation.All
 
-    function translateRiskScore(risk) {
-        if (risk < 15) {
-            return "Low"
-        } else {
-            return "Ligh"
-        }
-    }
-
     function performUpdate() {
         updatePending = false
         var filelist = download.fileList()
@@ -169,7 +161,7 @@ Page {
                         } else if (dbusproxy.isBusy) {
                             //% "Busy"
                             return qsTrId("contrac-main_la_status-busy")
-                        } else if (Settings.latestSummary.summationRiskScore >= 15) {
+                        } else if (riskStatus.riskClassIndex > 0) {
                             //% "At risk"
                             return qsTrId("contrac-main_la_status-daily-update-required")
                         } else if (downloadAvailable) {
@@ -200,7 +192,7 @@ Page {
                 x: Theme.horizontalPageMargin
                 //% "Risk status"
                 text: qsTrId("contrac-main_la_risk-status") + " : " + (!isNaN(Settings.summaryUpdated)
-                                                                       ? translateRiskScore(Settings.latestSummary.summationRiskScore)
+                                                                       ? riskStatus.riskClassLabel
                                                                          //% "Unknown"
                                                                        : qsTrId("contrac-main_la_risk-status-unknown"))
                 color: Theme.highlightColor

--- a/qml/pages/Main.qml
+++ b/qml/pages/Main.qml
@@ -33,9 +33,9 @@ Page {
 
     onStatusChanged: {
         if (status === PageStatus.Active) {
-            if (Settings.infoViewed === 0) {
+            if (AppSettings.infoViewed === 0) {
                 pageStack.push(Qt.resolvedUrl("Info.qml"));
-                Settings.infoViewed = 1;
+                AppSettings.infoViewed = 1;
             }
             if (updatePending) {
                 performUpdate()
@@ -59,8 +59,8 @@ Page {
                     console.log("Matched key count: " + summary.matchedKeyCount)
                     console.log("Maximum risk score: " + summary.maximumRiskScore)
                     console.log("Summation risk score: " + summary.summationRiskScore)
-                    Settings.summaryUpdated = new Date()
-                    Settings.latestSummary = summary
+                    AppSettings.summaryUpdated = new Date()
+                    AppSettings.latestSummary = summary
                 }
             }
         }
@@ -121,7 +121,7 @@ Page {
                             return Qt.resolvedUrl("image://contrac/icon-s-warning")
                         } else if (download.status === Download.StatusError) {
                             return Qt.resolvedUrl("image://contrac/icon-s-warning")
-                        } else if (Settings.latestSummary.summationRiskScore >= 15) {
+                        } else if (AppSettings.latestSummary.summationRiskScore >= 15) {
                             return Qt.resolvedUrl("image://contrac/icon-s-warning")
                         } else if (downloadAvailable) {
                             return Qt.resolvedUrl("image://contrac/icon-s-unknown")
@@ -191,7 +191,7 @@ Page {
                 width: parent.width - 2 * Theme.horizontalPageMargin
                 x: Theme.horizontalPageMargin
                 //% "Risk status"
-                text: qsTrId("contrac-main_la_risk-status") + " : " + (!isNaN(Settings.summaryUpdated)
+                text: qsTrId("contrac-main_la_risk-status") + " : " + (!isNaN(AppSettings.summaryUpdated)
                                                                        ? riskStatus.riskClassLabel
                                                                          //% "Unknown"
                                                                        : qsTrId("contrac-main_la_risk-status-unknown"))
@@ -203,8 +203,8 @@ Page {
                 width: parent.width - 2 * Theme.horizontalPageMargin
                 x: Theme.horizontalPageMargin
                 //% "Latest update"
-                text: qsTrId("contrac-main_la_last-update") + " : " + (!isNaN(Settings.summaryUpdated)
-                                                                       ? Qt.formatDateTime(Settings.summaryUpdated, "d MMM yyyy, hh:mm")
+                text: qsTrId("contrac-main_la_last-update") + " : " + (!isNaN(AppSettings.summaryUpdated)
+                                                                       ? Qt.formatDateTime(AppSettings.summaryUpdated, "d MMM yyyy, hh:mm")
                                                                          //% "Never"
                                                                        : qsTrId("contrac-main_la_latest-update-never"))
                 color: Theme.highlightColor
@@ -215,8 +215,8 @@ Page {
                 width: parent.width - 2 * Theme.horizontalPageMargin
                 x: Theme.horizontalPageMargin
                 //% "Days since last exposure"
-                text: qsTrId("contrac-main_la_days-since-last-exposure") + " : " + (Settings.latestSummary.matchedKeyCount > 0
-                                                                                    ? Settings.latestSummary.daysSinceLastExposure
+                text: qsTrId("contrac-main_la_days-since-last-exposure") + " : " + (AppSettings.latestSummary.matchedKeyCount > 0
+                                                                                    ? AppSettings.latestSummary.daysSinceLastExposure
                                                                                       //% "None recorded"
                                                                                     : qsTrId("contrac-main_la_days-since-last-exposure-none"))
                 color: Theme.highlightColor
@@ -227,7 +227,7 @@ Page {
                 width: parent.width - 2 * Theme.horizontalPageMargin
                 x: Theme.horizontalPageMargin
                 //% "Number of matched keys"
-                text: qsTrId("contrac-main_la_matched-keys") + " : " + Settings.latestSummary.matchedKeyCount
+                text: qsTrId("contrac-main_la_matched-keys") + " : " + AppSettings.latestSummary.matchedKeyCount
                 color: Theme.highlightColor
                 wrapMode: Text.Wrap
             }

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -6,9 +6,9 @@ import uk.co.flypig.contrac 1.0
 Page {
     id: settingsPage
 
-    Binding { target: Settings; property: "downloadServer"; value: downloadServerEntry.text }
-    Binding { target: Settings; property: "uploadServer"; value: uploadServerEntry.text }
-    Binding { target: Settings; property: "verificationServer"; value: verificationServerEntry.text }
+    Binding { target: AppSettings; property: "downloadServer"; value: downloadServerEntry.text }
+    Binding { target: AppSettings; property: "uploadServer"; value: uploadServerEntry.text }
+    Binding { target: AppSettings; property: "verificationServer"; value: verificationServerEntry.text }
     Binding { target: dbusproxy; property: "txPower"; value: txPowerEntry.text }
     Binding { target: dbusproxy; property: "rssiCorrection"; value: rssiCorrectionEntry.text }
 
@@ -42,7 +42,7 @@ Page {
                 label: qsTrId("contrac-settings_tf_download_server")
                 placeholderText: label
                 width: parent.width
-                text: Settings.downloadServer
+                text: AppSettings.downloadServer
                 inputMethodHints: Qt.ImhUrlCharactersOnly | Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
                 EnterKey.onClicked: uploadServerEntry.focus = true
@@ -54,7 +54,7 @@ Page {
                 label: qsTrId("contrac-settings_tf_upload_server")
                 placeholderText: label
                 width: parent.width
-                text: Settings.uploadServer
+                text: AppSettings.uploadServer
                 inputMethodHints: Qt.ImhUrlCharactersOnly | Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
                 EnterKey.onClicked: verificationServerEntry.focus = true
@@ -66,7 +66,7 @@ Page {
                 label: qsTrId("contrac-settings_tf_verification_server")
                 placeholderText: label
                 width: parent.width
-                text: Settings.verificationServer
+                text: AppSettings.verificationServer
                 inputMethodHints: Qt.ImhUrlCharactersOnly | Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
                 EnterKey.onClicked: txPowerEntry.focus = true

--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -4,13 +4,13 @@
 
 #include "../contracd/src/exposuresummary.h"
 
-#include "settings.h"
+#include "appsettings.h"
 
 #define SETTINGS_MAX_VERSION (1)
 
-Settings * Settings::instance = nullptr;
+AppSettings * AppSettings::instance = nullptr;
 
-Settings::Settings(QObject *parent) : QObject(parent),
+AppSettings::AppSettings(QObject *parent) : QObject(parent),
     m_settings(this)
 {
     m_downloadServer = m_settings.value(QStringLiteral("servers/downloadServer"), QStringLiteral("https://svc90.main.px.t-online.de")).toString();
@@ -60,7 +60,7 @@ Settings::Settings(QObject *parent) : QObject(parent),
     upgrade();
 }
 
-Settings::~Settings()
+AppSettings::~AppSettings()
 {
     m_settings.setValue(QStringLiteral("servers/downloadServer"), m_downloadServer);
     m_settings.setValue(QStringLiteral("servers/uploadServer"), m_uploadServer);
@@ -86,32 +86,33 @@ Settings::~Settings()
     }
     m_settings.endArray();
 
+    instance = nullptr;
     qDebug() << "Deleted settings";
 }
 
-void Settings::instantiate(QObject *parent) {
+void AppSettings::instantiate(QObject *parent) {
     if (instance == nullptr) {
-        instance = new Settings(parent);
+        instance = new AppSettings(parent);
     }
 }
 
-Settings & Settings::getInstance() {
+AppSettings & AppSettings::getInstance() {
     return *instance;
 }
 
-QObject * Settings::provider(QQmlEngine *engine, QJSEngine *scriptEngine) {
+QObject * AppSettings::provider(QQmlEngine *engine, QJSEngine *scriptEngine) {
     Q_UNUSED(engine)
     Q_UNUSED(scriptEngine)
 
     return instance;
 }
 
-QString Settings::downloadServer() const
+QString AppSettings::downloadServer() const
 {
     return m_downloadServer;
 }
 
-void Settings::setDownloadServer(QString const &downloadServer)
+void AppSettings::setDownloadServer(QString const &downloadServer)
 {
     if (m_downloadServer != downloadServer) {
         m_downloadServer = downloadServer;
@@ -119,12 +120,12 @@ void Settings::setDownloadServer(QString const &downloadServer)
     }
 }
 
-QString Settings::uploadServer() const
+QString AppSettings::uploadServer() const
 {
     return m_uploadServer;
 }
 
-void Settings::setUploadServer(QString const &uploadServer)
+void AppSettings::setUploadServer(QString const &uploadServer)
 {
     if (m_uploadServer != uploadServer) {
         m_uploadServer = uploadServer;
@@ -132,12 +133,12 @@ void Settings::setUploadServer(QString const &uploadServer)
     }
 }
 
-QString Settings::verificationServer() const
+QString AppSettings::verificationServer() const
 {
     return m_verificationServer;
 }
 
-void Settings::setVerificationServer(QString const &verificationServer)
+void AppSettings::setVerificationServer(QString const &verificationServer)
 {
     if (m_verificationServer != verificationServer) {
         m_verificationServer = verificationServer;
@@ -145,12 +146,12 @@ void Settings::setVerificationServer(QString const &verificationServer)
     }
 }
 
-ExposureSummary *Settings::latestSummary()
+ExposureSummary *AppSettings::latestSummary()
 {
     return &m_latestSummary;
 }
 
-void Settings::setLatestSummary(ExposureSummary const *latestSummary)
+void AppSettings::setLatestSummary(ExposureSummary const *latestSummary)
 {
     if (m_latestSummary != *latestSummary) {
         m_latestSummary = *latestSummary;
@@ -158,12 +159,12 @@ void Settings::setLatestSummary(ExposureSummary const *latestSummary)
     }
 }
 
-QDateTime Settings::summaryUpdated() const
+QDateTime AppSettings::summaryUpdated() const
 {
     return m_summaryUpdated;
 }
 
-void Settings::setSummaryUpdated(QDateTime summaryUpdated)
+void AppSettings::setSummaryUpdated(QDateTime summaryUpdated)
 {
     if (m_summaryUpdated != summaryUpdated) {
         m_summaryUpdated = summaryUpdated;
@@ -171,12 +172,12 @@ void Settings::setSummaryUpdated(QDateTime summaryUpdated)
     }
 }
 
-quint32 Settings::infoViewed() const
+quint32 AppSettings::infoViewed() const
 {
     return m_infoViewed;
 }
 
-void Settings::setInfoViewed(quint32 infoViewed)
+void AppSettings::setInfoViewed(quint32 infoViewed)
 {
     if (m_infoViewed != infoViewed) {
         m_infoViewed = infoViewed;
@@ -184,15 +185,15 @@ void Settings::setInfoViewed(quint32 infoViewed)
     }
 }
 
-QString Settings::getImageDir() const {
+QString AppSettings::getImageDir() const {
     return m_imageDir;
 }
 
-QString Settings::getImageUrl(QString const &id) const {
+QString AppSettings::getImageUrl(QString const &id) const {
     return m_imageDir + id + ".png";
 }
 
-bool Settings::upgrade()
+bool AppSettings::upgrade()
 {
     quint32 version;
     bool success = true;
@@ -228,7 +229,7 @@ bool Settings::upgrade()
     return success;
 }
 
-bool Settings::upgradeToVersion1()
+bool AppSettings::upgradeToVersion1()
 {
     bool success = true;
 
@@ -249,12 +250,12 @@ bool Settings::upgradeToVersion1()
     return success;
 }
 
-QList<double> Settings::riskWeights() const
+QList<double> AppSettings::riskWeights() const
 {
     return m_riskWeights;
 }
 
-void Settings::setRiskWeights(QList<double> riskWeights)
+void AppSettings::setRiskWeights(QList<double> riskWeights)
 {
     if (riskWeights.length() == 3) {
         if (m_riskWeights != riskWeights) {
@@ -267,12 +268,12 @@ void Settings::setRiskWeights(QList<double> riskWeights)
     }
 }
 
-qint32 Settings::defaultBuckeOffset() const
+qint32 AppSettings::defaultBuckeOffset() const
 {
     return m_defaultBuckeOffset;
 }
 
-void Settings::setDefaultBuckeOffset(qint32 defaultBuckeOffset)
+void AppSettings::setDefaultBuckeOffset(qint32 defaultBuckeOffset)
 {
     if (m_defaultBuckeOffset != defaultBuckeOffset) {
         m_defaultBuckeOffset = defaultBuckeOffset;
@@ -280,12 +281,12 @@ void Settings::setDefaultBuckeOffset(qint32 defaultBuckeOffset)
     }
 }
 
-qint32 Settings::normalizationDivisor() const
+qint32 AppSettings::normalizationDivisor() const
 {
     return m_normalizationDivisor;
 }
 
-void Settings::setNormalizationDivisor(qint32 normalizationDivisor)
+void AppSettings::setNormalizationDivisor(qint32 normalizationDivisor)
 {
     if (m_normalizationDivisor != normalizationDivisor) {
         m_normalizationDivisor = normalizationDivisor;
@@ -293,12 +294,12 @@ void Settings::setNormalizationDivisor(qint32 normalizationDivisor)
     }
 }
 
-QList<RiskScoreClass> Settings::riskScoreClasses() const
+QList<RiskScoreClass> AppSettings::riskScoreClasses() const
 {
     return m_riskScoreClasses;
 }
 
-void Settings::setRiskScoreClasses(QList<RiskScoreClass> riskScoreClasses)
+void AppSettings::setRiskScoreClasses(QList<RiskScoreClass> riskScoreClasses)
 {
     if (m_riskScoreClasses != riskScoreClasses) {
         m_riskScoreClasses = riskScoreClasses;

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -1,5 +1,5 @@
-#ifndef SETTINGS_H
-#define SETTINGS_H
+#ifndef APPSETTINGS_H
+#define APPSETTINGS_H
 
 #include <QObject>
 #include <QSettings>
@@ -11,7 +11,7 @@
 class QQmlEngine;
 class QJSEngine;
 
-class Settings : public QObject
+class AppSettings : public QObject
 {
     Q_OBJECT
 
@@ -30,11 +30,11 @@ class Settings : public QObject
     Q_PROPERTY(QList<RiskScoreClass> riskScoreClasses READ riskScoreClasses WRITE setRiskScoreClasses NOTIFY riskScoreClassesChanged)
 
 public:
-    explicit Settings(QObject *parent = nullptr);
-    ~Settings();
+    explicit AppSettings(QObject *parent = nullptr);
+    ~AppSettings();
 
     static void instantiate(QObject *parent = nullptr);
-    static Settings & getInstance();
+    static AppSettings & getInstance();
     static QObject * provider(QQmlEngine *engine, QJSEngine *scriptEngine);
 
     Q_INVOKABLE QString downloadServer() const;
@@ -81,7 +81,7 @@ private:
     bool upgradeToVersion1();
 
 private:
-    static Settings * instance;
+    static AppSettings * instance;
     QSettings m_settings;
 
     QString m_downloadServer;
@@ -97,4 +97,4 @@ private:
     QList<RiskScoreClass> m_riskScoreClasses;
 };
 
-#endif // SETTINGS_H
+#endif // APPSETTINGS_H

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -3,7 +3,7 @@
 #include <QDir>
 #include <QStandardPaths>
 
-#include "settings.h"
+#include "appsettings.h"
 #include "serveraccess.h"
 #include "downloadconfig.h"
 
@@ -110,7 +110,7 @@ Download::Download(QObject *parent) : QObject(parent)
 {
     m_serverAccess->setId("accessKey1");
     m_serverAccess->setSecret("verySecretKey1");
-    m_serverAccess->setBaseUrl(Settings::getInstance().downloadServer());
+    m_serverAccess->setBaseUrl(AppSettings::getInstance().downloadServer());
     m_serverAccess->setBucket("cwa");
 
     // Read from the filesystem
@@ -154,7 +154,7 @@ void Download::configDownloadComplete(QString const &)
     case DownloadConfig::ErrorNone:
         qDebug() << "Requesting keys";
         setStatus(StatusDownloadingKeys);
-        m_serverAccess->setBaseUrl(Settings::getInstance().downloadServer());
+        m_serverAccess->setBaseUrl(AppSettings::getInstance().downloadServer());
         startNextDateDownload();
         break;
     default:

--- a/src/downloadconfig.cpp
+++ b/src/downloadconfig.cpp
@@ -4,7 +4,7 @@
 #include "../contracd/src/exposureconfiguration.h"
 #include "../contracd/src/zipistreambuffer.h"
 
-#include "settings.h"
+#include "appsettings.h"
 #include "serveraccess.h"
 #include "applicationConfiguration.pb.h"
 
@@ -21,7 +21,7 @@ DownloadConfig::DownloadConfig(QObject *parent) : QObject(parent)
 {
     m_serverAccess->setId("accessKey1");
     m_serverAccess->setSecret("verySecretKey1");
-    m_serverAccess->setBaseUrl(Settings::getInstance().downloadServer());
+    m_serverAccess->setBaseUrl(AppSettings::getInstance().downloadServer());
     m_serverAccess->setBucket("cwa");
 
     connect(m_configuration, &ExposureConfiguration::minimumRiskScoreChanged, this, &DownloadConfig::configChanged);
@@ -43,7 +43,7 @@ Q_INVOKABLE void DownloadConfig::downloadLatest()
     qDebug() << "Requesting configuration";
 
     if (!m_downloading) {
-        m_serverAccess->setBaseUrl(Settings::getInstance().downloadServer());
+        m_serverAccess->setBaseUrl(AppSettings::getInstance().downloadServer());
         setStatus(StatusDownloading);
 
         QString key = "version/v1/configuration/country/DE/app_config";
@@ -179,7 +179,7 @@ void DownloadConfig::applyConfiguration(diagnosis::ApplicationConfiguration cons
 
     m_configuration->setMinimumRiskScore(appConfig.minriskscore());
     qDebug() << "Config min risk score: " << appConfig.minriskscore();
-    Settings &settings = Settings::getInstance();
+    AppSettings &settings = AppSettings::getInstance();
 
     if (appConfig.has_exposureconfig()) {
         const ::diagnosis::RiskScoreParameters& params = appConfig.exposureconfig();

--- a/src/downloadconfig.h
+++ b/src/downloadconfig.h
@@ -3,6 +3,8 @@
 
 #include <QObject>
 
+#include "riskscoreclass.h"
+
 class ServerAccess;
 class ExposureConfiguration;
 
@@ -45,6 +47,7 @@ signals:
     void statusChanged();
     void errorChanged();
     void configChanged();
+    void attenuationDurationConfigChanged();
 
 private slots:
     void setStatus(Status status);

--- a/src/harbour-contrac.cpp
+++ b/src/harbour-contrac.cpp
@@ -13,7 +13,7 @@
 #include "download.h"
 #include "downloadconfig.h"
 #include "upload.h"
-#include "settings.h"
+#include "appsettings.h"
 #include "imageprovider.h"
 #include "riskstatus.h"
 
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
     qRegisterMetaTypeStreamOperators<ExposureSummary>("ExposureSummary");
     qRegisterMetaTypeStreamOperators<RiskScoreClass>("RiskScoreClass");
 
-    Settings::instantiate(app);
+    AppSettings::instantiate(app);
 
     qmlRegisterType<DBusProxy>("uk.co.flypig.contrac", 1, 0, "DBusProxy");
     qmlRegisterType<TemporaryExposureKey>("uk.co.flypig.contrac", 1, 0, "TemporaryExposureKey");
@@ -59,11 +59,11 @@ int main(int argc, char *argv[])
     qmlRegisterType<DownloadConfig>("uk.co.flypig.contrac", 1, 0, "DownloadConfig");
     qmlRegisterType<RiskStatus>("uk.co.flypig.contrac", 1, 0, "RiskStatus");
 
-    qmlRegisterSingletonType<Settings>("uk.co.flypig.contrac", 1, 0, "Settings", Settings::provider);
+    qmlRegisterSingletonType<AppSettings>("uk.co.flypig.contrac", 1, 0, "AppSettings", AppSettings::provider);
 
     QQuickView *view = SailfishApp::createView();
     // The engine takes ownership of the ImageProvider
-    view->engine()->addImageProvider(QLatin1String("contrac"), new ImageProvider(Settings::getInstance()));
+    view->engine()->addImageProvider(QLatin1String("contrac"), new ImageProvider(AppSettings::getInstance()));
     view->setSource(SailfishApp::pathTo("qml/harbour-contrac.qml"));
     QQmlContext *ctxt = view->rootContext();
     ctxt->setContextProperty("version", VERSION);

--- a/src/harbour-contrac.cpp
+++ b/src/harbour-contrac.cpp
@@ -15,6 +15,7 @@
 #include "upload.h"
 #include "settings.h"
 #include "imageprovider.h"
+#include "riskstatus.h"
 
 #include <sailfishapp.h>
 
@@ -42,7 +43,9 @@ int main(int argc, char *argv[])
 
     // Needed for Settings save/load
     qRegisterMetaType<ExposureSummary>();
+    qRegisterMetaType<RiskScoreClass>();
     qRegisterMetaTypeStreamOperators<ExposureSummary>("ExposureSummary");
+    qRegisterMetaTypeStreamOperators<RiskScoreClass>("RiskScoreClass");
 
     Settings::instantiate(app);
 
@@ -54,6 +57,7 @@ int main(int argc, char *argv[])
     qmlRegisterType<Download>("uk.co.flypig.contrac", 1, 0, "Download");
     qmlRegisterType<Upload>("uk.co.flypig.contrac", 1, 0, "Upload");
     qmlRegisterType<DownloadConfig>("uk.co.flypig.contrac", 1, 0, "DownloadConfig");
+    qmlRegisterType<RiskStatus>("uk.co.flypig.contrac", 1, 0, "RiskStatus");
 
     qmlRegisterSingletonType<Settings>("uk.co.flypig.contrac", 1, 0, "Settings", Settings::provider);
 

--- a/src/imageprovider.cpp
+++ b/src/imageprovider.cpp
@@ -4,11 +4,11 @@
 #include <QColor>
 #include <QDebug>
 
-#include "settings.h"
+#include "appsettings.h"
 
 #include "imageprovider.h"
 
-ImageProvider::ImageProvider(Settings const &settings)
+ImageProvider::ImageProvider(AppSettings const &settings)
     : QQuickImageProvider(QQuickImageProvider::Pixmap)
     , m_imageDir(settings.getImageDir())
 {

--- a/src/imageprovider.h
+++ b/src/imageprovider.h
@@ -3,11 +3,11 @@
 
 #include <QQuickImageProvider>
 
-class Settings;
+class AppSettings;
 
 class ImageProvider : public QQuickImageProvider {
 public:
-    explicit ImageProvider(Settings const &settings);
+    explicit ImageProvider(AppSettings const &settings);
 
     QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize);
 private:

--- a/src/riskscoreclass.cpp
+++ b/src/riskscoreclass.cpp
@@ -1,0 +1,128 @@
+#include <QDataStream>
+
+#include "applicationConfiguration.pb.h"
+
+#include "riskscoreclass.h"
+
+RiskScoreClass::RiskScoreClass(QObject *parent)
+    : QObject(parent)
+    , m_label()
+    , m_min(0)
+    , m_max(0)
+{
+}
+
+RiskScoreClass::RiskScoreClass(RiskScoreClass const &riskScoreClass)
+    : QObject(riskScoreClass.parent())
+    , m_label(riskScoreClass.m_label)
+    , m_min(riskScoreClass.m_min)
+    , m_max(riskScoreClass.m_max)
+{
+}
+
+RiskScoreClass::RiskScoreClass(::diagnosis::RiskScoreClass const &riskScoreClass, QObject *parent)
+    : QObject(parent)
+{
+    m_label = QString::fromStdString(riskScoreClass.label());
+    m_min = riskScoreClass.min();
+    m_max = riskScoreClass.max();
+}
+
+RiskScoreClass& RiskScoreClass::operator=( const RiskScoreClass &other) {
+    if (this != &other) {
+        m_label = other.m_label;
+        m_min = other.m_min;
+        m_max = other.m_max;
+    }
+
+    return *this;
+}
+
+bool RiskScoreClass::operator==( const RiskScoreClass &other) const
+{
+    bool same;
+    same = (m_label == other.m_label) && (m_min == other.m_min) && (m_max == other.m_max);
+
+    return same;
+}
+
+bool RiskScoreClass::operator!=( const RiskScoreClass &other) const
+{
+    return !(*this == other);
+}
+
+bool RiskScoreClass::operator==( const ::diagnosis::RiskScoreClass &other) const
+{
+    bool same;
+    same = (m_label == QString::fromStdString(other.label())) && (m_min == other.min()) && (m_max == other.max());
+
+    return same;
+}
+
+bool RiskScoreClass::operator!=( const ::diagnosis::RiskScoreClass &other) const
+{
+    return !(*this == other);
+}
+
+QDataStream &operator<<(QDataStream &out, const RiskScoreClass &riskScoreClass)
+{
+    out << riskScoreClass.label();
+    out << riskScoreClass.min();
+    out << riskScoreClass.max();
+
+    return out;
+}
+
+QDataStream &operator>>(QDataStream &in, RiskScoreClass &riskScoreClass)
+{
+    QString valueString;
+    qint32 valueSignedInt;
+
+    in >> valueString;
+    riskScoreClass.setLabel(valueString);
+    in >> valueSignedInt;
+    riskScoreClass.setMax(valueSignedInt);
+    in >> valueSignedInt;
+    riskScoreClass.setMax(valueSignedInt);
+
+    return in;
+}
+
+QString RiskScoreClass::label() const
+{
+    return m_label;
+}
+
+void RiskScoreClass::setLabel(QString label)
+{
+    if (m_label != label) {
+        m_label = label;
+        emit labelChanged();
+    }
+}
+
+qint32 RiskScoreClass::min() const
+{
+    return m_min;
+}
+
+void RiskScoreClass::setMin(qint32 min)
+{
+    if (m_min != min) {
+        m_min = min;
+        emit minChanged();
+    }
+}
+
+qint32 RiskScoreClass::max() const
+{
+    return m_max;
+}
+
+void RiskScoreClass::setMax(qint32 max)
+{
+    if (m_max != max) {
+        m_max = max;
+        emit maxChanged();
+    }
+}

--- a/src/riskscoreclass.h
+++ b/src/riskscoreclass.h
@@ -1,0 +1,60 @@
+#ifndef RISCSCORECLASS_H
+#define RISCSCORECLASS_H
+
+#include <QObject>
+
+namespace diagnosis
+{
+class RiskScoreClass;
+}
+
+class RiskScoreClass : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
+    Q_PROPERTY(qint32 min READ min WRITE setMin NOTIFY minChanged)
+    Q_PROPERTY(qint32 max READ max WRITE setMax NOTIFY maxChanged)
+
+public:
+    explicit RiskScoreClass(QObject *parent = nullptr);
+    RiskScoreClass(RiskScoreClass const &riskScoreClass);
+    RiskScoreClass(::diagnosis::RiskScoreClass const &riskScoreClass, QObject *parent = nullptr);
+
+    RiskScoreClass& operator=( const RiskScoreClass &other);
+    bool operator==( const RiskScoreClass &other) const;
+    bool operator!=( const RiskScoreClass &other) const;
+
+    bool operator==( const ::diagnosis::RiskScoreClass &other) const;
+    bool operator!=( const ::diagnosis::RiskScoreClass &other) const;
+
+    Q_INVOKABLE QString label() const;
+    Q_INVOKABLE qint32 min() const;
+    Q_INVOKABLE qint32 max() const;
+
+public slots:
+    void setLabel(QString label);
+    void setMin(qint32 min);
+    void setMax(qint32 max);
+
+signals:
+    void labelChanged();
+    void minChanged();
+    void maxChanged();
+
+private:
+    QString m_label;
+    qint32 m_min;
+    qint32 m_max;
+
+signals:
+
+public slots:
+};
+
+QDataStream &operator<<(QDataStream &out, const RiskScoreClass &riskScoreClass);
+QDataStream &operator>>(QDataStream &in, RiskScoreClass &riskScoreClass);
+
+Q_DECLARE_METATYPE(RiskScoreClass)
+
+#endif // RISCSCORECLASS_H

--- a/src/riskstatus.cpp
+++ b/src/riskstatus.cpp
@@ -16,6 +16,10 @@ RiskStatus::RiskStatus(QObject *parent)
     connect(&settings, &AppSettings::normalizationDivisorChanged, this, &RiskStatus::recalculate);
     connect(&settings, &AppSettings::riskScoreClassesChanged, this, &RiskStatus::recalculate);
     connect(&settings, &AppSettings::latestSummaryChanged, this, &RiskStatus::updateExposureSummary);
+
+    m_maximumRiskScore = settings.latestSummary()->maximumRiskScore();
+    m_attenuationDurations = settings.latestSummary()->attenuationDurations();
+    m_combinedRiskScore = calculateRisk(m_maximumRiskScore, m_attenuationDurations);
 }
 
 void RiskStatus::recalculate()

--- a/src/riskstatus.cpp
+++ b/src/riskstatus.cpp
@@ -1,0 +1,105 @@
+#include "settings.h"
+
+#include "riskstatus.h"
+
+RiskStatus::RiskStatus(QObject *parent)
+    : QObject(parent)
+    , m_combinedRiskScore(0.0)
+    , m_maximumRiskScore(0)
+{
+    Settings &settings = Settings::getInstance();
+
+    connect(&settings, &Settings::riskWeightsChanged, this, &RiskStatus::recalculate);
+    connect(&settings, &Settings::defaultBuckeOffsetChanged, this, &RiskStatus::recalculate);
+    connect(&settings, &Settings::normalizationDivisorChanged, this, &RiskStatus::recalculate);
+    connect(&settings, &Settings::riskScoreClassesChanged, this, &RiskStatus::recalculate);
+    connect(&settings, &Settings::latestSummaryChanged, this, &RiskStatus::updateExposureSummary);
+}
+
+void RiskStatus::recalculate()
+{
+    double combinedRiskScore = calculateRisk(m_maximumRiskScore, m_attenuationDurations);
+    qint32 prevRiskClassIndex = riskClassIndex();
+    if (m_combinedRiskScore != combinedRiskScore) {
+        m_combinedRiskScore = combinedRiskScore;
+        emit combinedRiskScoreChanged();
+    }
+    if (riskClassIndex() != prevRiskClassIndex) {
+        emit riskClassChanged();
+    }
+}
+
+double RiskStatus::combinedRiskScore() const
+{
+    return m_combinedRiskScore;
+}
+
+qint32 RiskStatus::riskClassIndex() const
+{
+    return calculateRiskClassIndex(m_combinedRiskScore);
+}
+
+QString RiskStatus::riskClassLabel() const
+{
+    return calculateRiskClassLabel(m_combinedRiskScore);
+}
+
+void RiskStatus::updateExposureSummary()
+{
+    ExposureSummary const *exposureSummary = Settings::getInstance().latestSummary();
+
+    if (exposureSummary) {
+        m_maximumRiskScore = exposureSummary->maximumRiskScore();
+        m_attenuationDurations = exposureSummary->attenuationDurations();
+        recalculate();
+    }
+}
+
+double RiskStatus::calculateRisk(qint32 riskScore, QList<qint32> const &attenuationDurations) const
+{
+    double risk = 0.0;
+    Settings &settings = Settings::getInstance();
+
+    if ((attenuationDurations.size() == 3) && (settings.riskWeights().size() == 3) && (settings.normalizationDivisor() > 0)) {
+        double exposureScore = 0.0;
+        double normalizedScore = 0.0;
+        exposureScore += attenuationDurations[0] * settings.riskWeights()[0];
+        exposureScore += attenuationDurations[1] * settings.riskWeights()[1];
+        exposureScore += attenuationDurations[2] * settings.riskWeights()[2];
+        normalizedScore = double(riskScore) / double(settings.normalizationDivisor());
+
+        risk = exposureScore * normalizedScore;
+    }
+
+    return risk;
+}
+
+qint32 RiskStatus::calculateRiskClassIndex(double combinedRiskScore) const
+{
+    qint32 pos = 0;
+    qint32 result = -1;
+    QList<RiskScoreClass> const &riskScoreClasses = Settings::getInstance().riskScoreClasses();
+    while ((pos < riskScoreClasses.size()) && (result < 0)) {
+        if ((combinedRiskScore >= riskScoreClasses[pos].min()) && (combinedRiskScore < riskScoreClasses[pos].max())) {
+            result = pos;
+        }
+        ++pos;
+    }
+    return result;
+}
+
+QString RiskStatus::calculateRiskClassLabel(double combinedRiskScore) const
+{
+    qint32 index = calculateRiskClassIndex(combinedRiskScore);
+    QString label;
+    QList<RiskScoreClass> const &riskScoreClasses = Settings::getInstance().riskScoreClasses();
+
+    if ((index >= 0) && (index < riskScoreClasses.size())) {
+        label = riskScoreClasses[index].label().toLower();
+        // Sentence case
+        label[0] = label[0].toUpper();
+    }
+
+    return label;
+}
+

--- a/src/riskstatus.h
+++ b/src/riskstatus.h
@@ -1,0 +1,44 @@
+#ifndef RISKSTATUS_H
+#define RISKSTATUS_H
+
+#include <QObject>
+
+class ExposureSummary;
+
+class RiskStatus : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(double combinedRiskScore READ combinedRiskScore NOTIFY combinedRiskScoreChanged)
+    Q_PROPERTY(qint32 riskClassIndex READ riskClassIndex NOTIFY riskClassChanged)
+    Q_PROPERTY(QString riskClassLabel READ riskClassLabel NOTIFY riskClassChanged)
+
+public:
+    explicit RiskStatus(QObject *parent = nullptr);
+
+    qint32 totalRiskScore() const;
+    double combinedRiskScore() const;
+    qint32 riskClassIndex() const;
+    QString riskClassLabel() const;
+
+signals:
+    void totalRiskScoreChanged();
+    void combinedRiskScoreChanged();
+    void riskClassChanged();
+
+private slots:
+    void recalculate();
+    void updateExposureSummary();
+
+private:
+    double calculateRisk(qint32 combinedRiskScore, QList<qint32> const &attenuationDurations) const;
+    qint32 calculateRiskClassIndex(double combinedRiskScore) const;
+    QString calculateRiskClassLabel(double combinedRiskScore) const;
+
+private:
+    double m_combinedRiskScore;
+    qint32 m_maximumRiskScore;
+    QList<qint32> m_attenuationDurations;
+};
+
+#endif // RISKSTATUS_H

--- a/src/settings.h
+++ b/src/settings.h
@@ -2,11 +2,14 @@
 #define SETTINGS_H
 
 #include <QObject>
-#include <QQmlEngine>
 #include <QSettings>
 #include <QDate>
 
+#include "riskscoreclass.h"
 #include "../contracd/src/exposuresummary.h"
+
+class QQmlEngine;
+class QJSEngine;
 
 class Settings : public QObject
 {
@@ -19,6 +22,12 @@ class Settings : public QObject
     Q_PROPERTY(ExposureSummary *latestSummary READ latestSummary WRITE setLatestSummary NOTIFY latestSummaryChanged)
     Q_PROPERTY(QDateTime summaryUpdated READ summaryUpdated WRITE setSummaryUpdated NOTIFY summaryUpdatedChanged)
     Q_PROPERTY(quint32 infoViewed READ infoViewed WRITE setInfoViewed NOTIFY infoViewedChanged)
+
+    // Attenuation duration properties
+    Q_PROPERTY(QList<double> riskWeights READ riskWeights WRITE setRiskWeights NOTIFY riskWeightsChanged)
+    Q_PROPERTY(qint32 defaultBuckeOffset READ defaultBuckeOffset WRITE setDefaultBuckeOffset NOTIFY defaultBuckeOffsetChanged)
+    Q_PROPERTY(qint32 normalizationDivisor READ normalizationDivisor WRITE setNormalizationDivisor NOTIFY normalizationDivisorChanged)
+    Q_PROPERTY(QList<RiskScoreClass> riskScoreClasses READ riskScoreClasses WRITE setRiskScoreClasses NOTIFY riskScoreClassesChanged)
 
 public:
     explicit Settings(QObject *parent = nullptr);
@@ -35,6 +44,11 @@ public:
     Q_INVOKABLE QDateTime summaryUpdated() const;
     Q_INVOKABLE quint32 infoViewed() const;
 
+    Q_INVOKABLE QList<double> riskWeights() const;
+    Q_INVOKABLE qint32 defaultBuckeOffset() const;
+    Q_INVOKABLE qint32 normalizationDivisor() const;
+    Q_INVOKABLE QList<RiskScoreClass> riskScoreClasses() const;
+
     Q_INVOKABLE QString getImageDir() const;
     Q_INVOKABLE QString getImageUrl(QString const &id) const;
 
@@ -45,6 +59,10 @@ signals:
     void latestSummaryChanged();
     void summaryUpdatedChanged();
     void infoViewedChanged();
+    void riskWeightsChanged();
+    void defaultBuckeOffsetChanged();
+    void normalizationDivisorChanged();
+    void riskScoreClassesChanged();
 
 public slots:
     void setDownloadServer(QString const &downloadServer);
@@ -53,6 +71,10 @@ public slots:
     void setLatestSummary(ExposureSummary const *latestSummary);
     void setSummaryUpdated(QDateTime summaryUpdated);
     void setInfoViewed(quint32 infoViewed);
+    void setRiskWeights(QList<double> riskWeights);
+    void setDefaultBuckeOffset(qint32 defaultBuckeOffset);
+    void setNormalizationDivisor(qint32 normalizationDivisor);
+    void setRiskScoreClasses(QList<RiskScoreClass> riskScoreClasses);
 
 private:
     bool upgrade();
@@ -69,6 +91,10 @@ private:
     QDateTime m_summaryUpdated;
     quint32 m_infoViewed;
     QString m_imageDir;
+    QList<double> m_riskWeights;
+    qint32 m_defaultBuckeOffset;
+    qint32 m_normalizationDivisor;
+    QList<RiskScoreClass> m_riskScoreClasses;
 };
 
 #endif // SETTINGS_H

--- a/src/upload.cpp
+++ b/src/upload.cpp
@@ -7,7 +7,7 @@
 #include <openssl/evp.h>
 
 #include "submissionpayload.pb.h"
-#include "settings.h"
+#include "appsettings.h"
 
 #include "upload.h"
 
@@ -46,7 +46,7 @@ void Upload::submitTeleTAN(QString const &teleTAN)
     if ((m_status == StatusSubmitTeleTAN) && (m_reply == nullptr)) {
         QNetworkRequest request;
 
-        request.setUrl(QUrl(Settings::getInstance().verificationServer() + "/version/v1/registrationToken"));
+        request.setUrl(QUrl(AppSettings::getInstance().verificationServer() + "/version/v1/registrationToken"));
         request.setRawHeader("accept", "*/*");
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("cwa-fake", "0");
@@ -114,7 +114,7 @@ void Upload::submitRegToken(QString const &regToken)
     if ((m_status == StatusSubmitRegToken) && (m_reply == nullptr)) {
         QNetworkRequest request;
 
-        request.setUrl(QUrl(Settings::getInstance().verificationServer() + "/version/v1/tan"));
+        request.setUrl(QUrl(AppSettings::getInstance().verificationServer() + "/version/v1/tan"));
         request.setRawHeader("accept", "*/*");
         request.setRawHeader("Content-Type", "application/json");
         request.setRawHeader("cwa-fake", "0");
@@ -212,7 +212,7 @@ void Upload::submitDiagnosisKeys(QString const &tan)
             QByteArray data = QByteArray::fromStdString(payload.SerializeAsString());
             qDebug() << "Upload size: " << data.length();
 
-            request.setUrl(QUrl(Settings::getInstance().uploadServer() + "/version/v1/diagnosis-keys"));
+            request.setUrl(QUrl(AppSettings::getInstance().uploadServer() + "/version/v1/diagnosis-keys"));
             request.setRawHeader("accept", "*/*");
             request.setRawHeader("Content-Type", "application/x-protobuf");
             request.setRawHeader("cwa-authorization", tan.toLatin1());

--- a/src/upload.cpp
+++ b/src/upload.cpp
@@ -6,7 +6,7 @@
 
 #include <openssl/evp.h>
 
-#include "proto/submissionpayload.pb.h"
+#include "submissionpayload.pb.h"
 #include "settings.h"
 
 #include "upload.h"

--- a/tests/mock/sailfishapp.h
+++ b/tests/mock/sailfishapp.h
@@ -1,0 +1,19 @@
+#ifndef MOCK_SAILFISHAPP_H
+#define MOCK_SAILFISHAPP_H
+
+#include <QObject>
+#include <QUrl>
+
+class SailfishApp : public QObject
+{
+    Q_OBJECT
+
+public:
+    static QUrl pathTo(QString const path)
+    {
+        return QUrl(QStringLiteral("./") + path);
+    }
+};
+
+#endif // MOCK_SAILFISHAPP_H
+

--- a/tests/test_tracing.cpp
+++ b/tests/test_tracing.cpp
@@ -9,7 +9,8 @@
 #include "../contracd/src/exposurenotification_p.h"
 #include "../contracd/src/exposureconfiguration.h"
 #include "../contracd/proto/contrac.pb.h"
-#include "../src/downloadconfig.h"
+#include "../src/appsettings.h"
+#include "../src/riskstatus.h"
 
 #include "test_tracing.h"
 
@@ -67,11 +68,18 @@ Test_Tracing::Test_Tracing(QObject *parent) : QObject(parent)
     QCoreApplication::setOrganizationDomain("www.flypig.co.uk");
     QCoreApplication::setOrganizationName("harbour-contrac");
     QCoreApplication::setApplicationName("harbour-contrac-tests");
+
+    // Needed for Settings save/load
+    qRegisterMetaType<ExposureSummary>();
+    qRegisterMetaType<RiskScoreClass>();
+    qRegisterMetaTypeStreamOperators<ExposureSummary>("ExposureSummary");
+    qRegisterMetaTypeStreamOperators<RiskScoreClass>("RiskScoreClass");
 }
 
 void Test_Tracing::init()
 {
     Settings::instantiate(this);
+    AppSettings::instantiate(this);
 }
 
 void Test_Tracing::cleanup()
@@ -80,6 +88,8 @@ void Test_Tracing::cleanup()
 
     Settings &settings = Settings::getInstance();
     delete &settings;
+    AppSettings &appSettings = AppSettings::getInstance();
+    delete &appSettings;
     QString folder = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
     qDebug() << "Removing folder" << folder;
     QDir dir(folder);
@@ -731,8 +741,118 @@ void Test_Tracing::testDiagnosis()
     QVERIFY(result);
 }
 
-void Test_Tracing::testDownloadConfig()
+void Test_Tracing::testCombinedRiskScore()
 {
+    RiskStatus riskStatus;
+    AppSettings &settings = AppSettings::getInstance();
+
+    QList<double> riskWeights;
+    QList<RiskScoreClass> riskScoreClasses;
+    RiskScoreClass riskScoreClass;
+    ExposureSummary exposureSummary;
+    QList<qint32> attenuationDurations;
+
+    // For the calculation see
+    // https://github.com/corona-warn-app/cwa-documentation/blob/master/solution_architecture.md#user-content-risk-score-calculation
+
+    // Default values, no exposure events
+    // ((0 * 1.0) + (0 * 0.5) + (0 * 0.0) + 0) * (25 / 25) = 0
+    // Index 0 (Low) since 0 \in [0, 15), 0 \not\in [15, 72)
+    riskWeights.clear();
+    riskWeights.append(1.0);
+    riskWeights.append(0.5);
+    riskWeights.append(0.0);
+    settings.setRiskWeights(riskWeights);
+    settings.setDefaultBuckeOffset(0.0);
+    settings.setNormalizationDivisor(25);
+    riskScoreClasses.clear();
+    riskScoreClass.setLabel("LOW");
+    riskScoreClass.setMin(0);
+    riskScoreClass.setMax(15);
+    riskScoreClasses.append(riskScoreClass);
+    riskScoreClass.setLabel("HIGH");
+    riskScoreClass.setMin(15);
+    riskScoreClass.setMax(72);
+    riskScoreClasses.append(riskScoreClass);
+    settings.setRiskScoreClasses(riskScoreClasses);
+
+    exposureSummary.setMaximumRiskScore(25);
+    attenuationDurations.clear();
+    attenuationDurations.append(0);
+    attenuationDurations.append(0);
+    attenuationDurations.append(0);
+    exposureSummary.setAttenuationDurations(attenuationDurations);
+    settings.setLatestSummary(&exposureSummary);
+
+    QCOMPARE(riskStatus.combinedRiskScore(), 0.0);
+    QCOMPARE(riskStatus.riskClassIndex(), 0);
+    QCOMPARE(riskStatus.riskClassLabel(), QStringLiteral("Low"));
+
+    // Default values, some plausible exposure events
+    // ((20 * 1.0) + (50 * 0.5) + (10 * 0.0) + 0) * (10 / 25) = 18
+    // Index 1 (High) since 18 \not\in [0, 15), 18 \in [15, 72)
+    riskWeights.clear();
+    riskWeights.append(1.0);
+    riskWeights.append(0.5);
+    riskWeights.append(0.0);
+    settings.setRiskWeights(riskWeights);
+    settings.setDefaultBuckeOffset(0.0);
+    settings.setNormalizationDivisor(25);
+    riskScoreClasses.clear();
+    riskScoreClass.setLabel("LOW");
+    riskScoreClass.setMin(0);
+    riskScoreClass.setMax(15);
+    riskScoreClasses.append(riskScoreClass);
+    riskScoreClass.setLabel("HIGH");
+    riskScoreClass.setMin(15);
+    riskScoreClass.setMax(72);
+    riskScoreClasses.append(riskScoreClass);
+    settings.setRiskScoreClasses(riskScoreClasses);
+
+    exposureSummary.setMaximumRiskScore(10);
+    attenuationDurations.clear();
+    attenuationDurations.append(20);
+    attenuationDurations.append(50);
+    attenuationDurations.append(10);
+    exposureSummary.setAttenuationDurations(attenuationDurations);
+    settings.setLatestSummary(&exposureSummary);
+
+    QCOMPARE(riskStatus.combinedRiskScore(), 18.0);
+    QCOMPARE(riskStatus.riskClassIndex(), 1);
+    QCOMPARE(riskStatus.riskClassLabel(), QStringLiteral("High"));
+
+    // Arbitrary values, some arbitrary exposure events
+    // ((5 * 7.0) + (11 * 3.0) + (13 * 2.0) + 5) * (2 / 18) = 11
+    // Index 1 (High) since 11 \not\in [0, 10), 11 \in [10, 20)
+    riskWeights.clear();
+    riskWeights.append(7.0);
+    riskWeights.append(3.0);
+    riskWeights.append(2.0);
+    settings.setRiskWeights(riskWeights);
+    settings.setDefaultBuckeOffset(5.0);
+    settings.setNormalizationDivisor(18);
+    riskScoreClasses.clear();
+    riskScoreClass.setLabel("LOW");
+    riskScoreClass.setMin(0);
+    riskScoreClass.setMax(10);
+    riskScoreClasses.append(riskScoreClass);
+    riskScoreClass.setLabel("HIGH");
+    riskScoreClass.setMin(10);
+    riskScoreClass.setMax(20);
+    riskScoreClasses.append(riskScoreClass);
+    settings.setRiskScoreClasses(riskScoreClasses);
+
+    exposureSummary.setMaximumRiskScore(2);
+    attenuationDurations.clear();
+    attenuationDurations.append(5);
+    attenuationDurations.append(11);
+    attenuationDurations.append(13);
+    exposureSummary.setAttenuationDurations(attenuationDurations);
+    settings.setLatestSummary(&exposureSummary);
+
+    QCOMPARE(riskStatus.combinedRiskScore(), 11.0);
+    QCOMPARE(riskStatus.riskClassIndex(), 1);
+    QCOMPARE(riskStatus.riskClassLabel(), QStringLiteral("High"));
 }
 
 QTEST_APPLESS_MAIN(Test_Tracing)

--- a/tests/test_tracing.cpp
+++ b/tests/test_tracing.cpp
@@ -9,6 +9,7 @@
 #include "../contracd/src/exposurenotification_p.h"
 #include "../contracd/src/exposureconfiguration.h"
 #include "../contracd/proto/contrac.pb.h"
+#include "../src/downloadconfig.h"
 
 #include "test_tracing.h"
 
@@ -728,6 +729,10 @@ void Test_Tracing::testDiagnosis()
     diagnosis::TemporaryExposureKeyExport keyExport;
     result = ExposureNotificationPrivate::loadDiagnosisKeys("/usr/share/harbour-contrac-tests/sample_diagnosis_key_file.zip", &keyExport);
     QVERIFY(result);
+}
+
+void Test_Tracing::testDownloadConfig()
+{
 }
 
 QTEST_APPLESS_MAIN(Test_Tracing)

--- a/tests/test_tracing.h
+++ b/tests/test_tracing.h
@@ -21,6 +21,7 @@ private slots:
     void testStorage();
     void testMatch();
     void testDiagnosis();
+    void testDownloadConfig();
 };
 
 #endif // TEST_STORAGE_H

--- a/tests/test_tracing.h
+++ b/tests/test_tracing.h
@@ -21,7 +21,7 @@ private slots:
     void testStorage();
     void testMatch();
     void testDiagnosis();
-    void testDownloadConfig();
+    void testCombinedRiskScore();
 };
 
 #endif // TEST_STORAGE_H

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -25,9 +25,10 @@ QMAKE_EXTRA_TARGETS = check
 check.depends = $$TARGET
 check.commands = LD_LIBRARY_PATH=../../lib ./$$TARGET
 
-INCLUDEPATH += ../src/
+INCLUDEPATH += ../src/ ./mock/
 
 PKGCONFIG += \
+    mlite5 \
     openssl \
     protobuf-lite \
     quazip
@@ -38,7 +39,11 @@ HEADERS += \
     test_tracing.h
 
 HEADERS += \
+    mock/sailfishapp.h \
     ../src/contactmodel.h \
+    ../src/appsettings.h \
+    ../src/riskstatus.h \
+    ../src/riskscoreclass.h \
     ../contracd/proto/contrac.pb.h \
     ../contracd/src/bleadvertisement.h \
     ../contracd/src/bleadvertisementmanager.h \
@@ -66,6 +71,9 @@ HEADERS += \
 
 SOURCES += \
     ../src/contactmodel.cpp \
+    ../src/appsettings.cpp \
+    ../src/riskstatus.cpp \
+    ../src/riskscoreclass.cpp \
     ../contracd/proto/contrac.pb.cc \
     ../contracd/src/bleadvertisement.cpp \
     ../contracd/src/bleadvertisementmanager.cpp \

--- a/translations/harbour-contrac-de.ts
+++ b/translations/harbour-contrac-de.ts
@@ -301,11 +301,11 @@
     </message>
     <message id="contrac-info_configure-attenuation-calibration-values">
         <source>You should configure the Bluetooth attenuation calibration values before using this app. Please visit the Settings page to do this.</source>
-        <translation>Bevor Sie diese App benutzen, sollten Sie die Bluetooth-spezifischen Dämpfungs-Kalibrierungsvariablen konfigurieren. Bitte besuchen Sie die &ldquo;Einstellungen&rdquo;-Seite, um dies vorzunehmen.</translation>
+        <translation>Bevor Sie diese App benutzen, sollten Sie die Bluetooth-spezifischen Dämpfungs-Kalibrierungsvariablen konfigurieren. Bitte besuchen Sie die “Einstellungen”-Seite, um dies vorzunehmen.</translation>
     </message>
     <message id="contrac-info_view-again">
         <source>You can view this page again by visiting the About page.</source>
-        <translation>Sie können diese Seite erneut aufrufen, indem Sie die &ldquo;Über&rdquo;-Seite besuchen.</translation>
+        <translation>Sie können diese Seite erneut aufrufen, indem Sie die “Über”-Seite besuchen.</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
The Corona-Warn-App does some post-processing to refine the risk level
calculates by the GApple API, as explained here:

https://github.com/corona-warn-app/cwa-documentation/blob/master/solution_architecture.md#risk-score-calculation

In short, this multiplies each of the attenuation durations by a weight,
adds them together along with a constant, multiplies the result by the
GApple risk score, and divides by a normalizing factor.

The weights, constant and factor are supplied through the configuration
file downloaded from the servers.

This change stores the configuration values and provides methods for
calculating the combined risk score.

Closes #49.