### PR TITLE
Allow graceful shutdown if filtering not supported

### DIFF
--- a/contracd/src/blescanner.cpp
+++ b/contracd/src/blescanner.cpp
@@ -168,12 +168,12 @@ void BleScanner::startDiscovery()
 
 void BleScanner::removeDiscoveryFilter()
 {
-    if (m_filteringSupported) {
-        qDebug() << "Removing discovery filter";
+    qDebug() << "Removing discovery filter";
+    m_scanState = RemovingFilter;
 
+    if (m_filteringSupported) {
         QDBusPendingCall async = m_adapterInterface->asyncCall("SetDiscoveryFilter", QVariantMap());
 
-        m_scanState = RemovingFilter;
         QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(async, this);
 
         connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* call) {


### PR DESCRIPTION
On some devices BLE filtering isn't supported, but this doesn't
necessarily prevent scanning from working.

However, a logic error in the state machine was preventing the scanner from
shutting down gracefully.

This change fixes the state machine error.