### PR TITLE
Move risk calculation into a separate thread

### DIFF
--- a/contracd/contracd.pro
+++ b/contracd/contracd.pro
@@ -44,6 +44,7 @@ HEADERS += \
     src/fnv.h \
     src/hkdfsha256.h \
     src/metadata.h \
+    src/providediagnostickeys.h \
     src/rpidataitem.h \
     src/settings.h \
     src/temporaryexposurekey.h \
@@ -71,6 +72,7 @@ SOURCES += \
     src/fnv.cpp \
     src/hkdfsha256.cpp \
     src/metadata.cpp \
+    src/providediagnostickeys.cpp \
     src/rpidataitem.cpp \
     src/settings.cpp \
     src/temporaryexposurekey.cpp \

--- a/contracd/src/bleadvertisementmanager.cpp
+++ b/contracd/src/bleadvertisementmanager.cpp
@@ -15,6 +15,10 @@
 #include "bleadvertisement.h"
 #include "bleadvertisementmanager.h"
 
+// D-bus timeout in milliseconds
+// When bluez is busy, it can take a while to get a response from RegisterAdvertisement
+#define DBUS_PROXY_TIMEOUT (10 * 60 * 1000)
+
 BleAdvertisementManager::BleAdvertisementManager(QObject *parent)
     : QObject(parent)
     , m_interface(nullptr)
@@ -27,6 +31,7 @@ void BleAdvertisementManager::connectDBus()
 
     qDebug() << "Registering interface";
     m_interface = new QDBusInterface("org.bluez", path, "org.bluez.LEAdvertisingManager1", QDBusConnection::systemBus(), this);
+    m_interface->setTimeout(DBUS_PROXY_TIMEOUT);
 
     QStringList argumentMatch;
     argumentMatch.append("org.bluez.LEAdvertisingManager1");

--- a/contracd/src/contactstorage.cpp
+++ b/contracd/src/contactstorage.cpp
@@ -27,6 +27,10 @@ ContactStorage::ContactStorage(Contrac *parent)
 
 ContactStorage::~ContactStorage()
 {
+    if (m_other) {
+        delete m_other;
+        m_other = nullptr;
+    }
 }
 
 void ContactStorage::onTimeChanged()
@@ -76,10 +80,10 @@ DayStorage * ContactStorage::getStorage(quint32 day) {
     }
     else {
         if (!m_other || (day != m_other->dayNumber())) {
-                if (m_other) {
+            if (m_other) {
                 delete m_other;
             }
-            m_other = new DayStorage(day, this);
+            m_other = new DayStorage(day);
         }
         storage = m_other;
     }

--- a/contracd/src/contactstorage.h
+++ b/contracd/src/contactstorage.h
@@ -8,7 +8,7 @@
 #include "diagnosiskey.h"
 
 // Amount of data to store
-#define DAYS_TO_STORE (14u)
+#define DAYS_TO_STORE (15)
 
 class Contrac;
 class DayStorage;

--- a/contracd/src/daystorage.cpp
+++ b/contracd/src/daystorage.cpp
@@ -37,17 +37,20 @@ QList<RpiDataItem> DayStorage::findRpiMatches(QList<QByteArray> const &rpis)
     QFile captures;
     QString leafname;
 
+    m_filterMutex.lock();
     QList<QByteArray> probables;
     for (QByteArray const &rpi : rpis) {
         if (m_filter->test(rpi)) {
             probables.append(rpi);
         }
     }
+    m_filterMutex.unlock();
 
     QList<RpiDataItem> actuals;
 
     QString folder = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/contacts";
 
+    m_contactsMutex.lock();
     leafname = QStringLiteral("%1.dat");
     leafname = leafname.arg(m_day, 8, 16, QLatin1Char('0'));
     captures.setFileName(folder + "/" + leafname);
@@ -76,6 +79,7 @@ QList<RpiDataItem> DayStorage::findRpiMatches(QList<QByteArray> const &rpis)
     else {
         qDebug() << "Error opening data file: " << captures.fileName();
     }
+    m_contactsMutex.unlock();
 
     return actuals;
 }
@@ -99,6 +103,7 @@ QList<ContactMatch> DayStorage::findDtkMatches(QList<DiagnosisKey> const &dtks)
         else {
             endTime = startTime + static_cast<quint8>(dtk.m_rollingPeriod);
         }
+        m_filterMutex.lock();
         // Generate up to 144 rpis for each dtk
         for (quint8 interval = startTime; interval < endTime; ++interval) {
             QByteArray rpi(Contrac::randomProximityIdentifier(dtk.m_dtk, interval));
@@ -109,6 +114,7 @@ QList<ContactMatch> DayStorage::findDtkMatches(QList<DiagnosisKey> const &dtks)
                 probable.m_rpis.append(RpiDataItem(quantised, 0, rpi, QByteArray(AEM_SIZE, '\0')));
             }
         }
+        m_filterMutex.unlock();
         if (probable.m_rpis.size() > 0) {
             probables.append(probable);
             actuals.append(QList<RpiDataItem>());
@@ -116,64 +122,71 @@ QList<ContactMatch> DayStorage::findDtkMatches(QList<DiagnosisKey> const &dtks)
     }
     qDebug() << "Probables size: " << probables.size();
 
-    // Now go through in detail and filter out any errors
-    // Adding in rssi values as we go
-    QString folder = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/contacts";
-    leafname = QStringLiteral("%1.dat");
-    leafname = leafname.arg(m_day, 8, 16, QLatin1Char('0'));
-    captures.setFileName(folder + "/" + leafname);
-    result = captures.open(QIODevice::ReadOnly);
-    if (result) {
-        QByteArray capture = captures.read(RPI_SERIALISE_SIZE);
-        while (!capture.isEmpty() && !probables.isEmpty()) {
-            RpiDataItem rpi;
-            result = rpi.deserialise(capture);
-            if (result) {
-                // Cycle through the dtks
-                int dtk_pos = 0;
-                while (dtk_pos < probables.size()) {
-                    // Cycle through the rpis associated with this dtk
-                    int rpi_pos = 0;
-                    ContactMatch &probable = probables[dtk_pos];
-                    while (rpi_pos < probable.m_rpis.size()) {
-                        RpiDataItem &probable_rpi = probable.m_rpis[rpi_pos];
-                        if ((rpi.m_rpi == probable_rpi.m_rpi) && ctIntervalsMatch(rpi.m_interval, probable_rpi.m_interval)) {
-                            // We have a match!
-                            // There could be multiple beacons matching this rpi, so we can't remove it yet
-                            actuals[dtk_pos].append(rpi);
-                        }
-                        else {
-                            if (rpi.m_rpi == probable_rpi.m_rpi) {
-                                qDebug() << "Failed due to time mismatch";
-                                qDebug() << "Beacon time: " << rpi.m_interval;
-                                qDebug() << "Diagnosis time: " << probable_rpi.m_interval;
+    // There's no point opening the captures file unless there are some probables to check
+    if (!probables.isEmpty()) {
+        // Now go through in detail and filter out any errors
+        // Adding in rssi values as we go
+        m_contactsMutex.lock();
+        QString folder = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/contacts";
+        leafname = QStringLiteral("%1.dat");
+        leafname = leafname.arg(m_day, 8, 16, QLatin1Char('0'));
+        captures.setFileName(folder + "/" + leafname);
+        result = captures.open(QIODevice::ReadOnly);
+        if (result) {
+            QByteArray capture = captures.read(RPI_SERIALISE_SIZE);
+            while (!capture.isEmpty() && !probables.isEmpty()) {
+                RpiDataItem rpi;
+                result = rpi.deserialise(capture);
+                if (result) {
+                    // Cycle through the dtks
+                    int dtk_pos = 0;
+                    while (dtk_pos < probables.size()) {
+                        // Cycle through the rpis associated with this dtk
+                        int rpi_pos = 0;
+                        ContactMatch &probable = probables[dtk_pos];
+                        while (rpi_pos < probable.m_rpis.size()) {
+                            RpiDataItem &probable_rpi = probable.m_rpis[rpi_pos];
+                            if ((rpi.m_rpi == probable_rpi.m_rpi) && ctIntervalsMatch(rpi.m_interval, probable_rpi.m_interval)) {
+                                // We have a match!
+                                // There could be multiple beacons matching this rpi, so we can't remove it yet
+                                actuals[dtk_pos].append(rpi);
                             }
+                            else {
+                                if (rpi.m_rpi == probable_rpi.m_rpi) {
+                                    qDebug() << "Failed due to time mismatch";
+                                    qDebug() << "Beacon time: " << rpi.m_interval;
+                                    qDebug() << "Diagnosis time: " << probable_rpi.m_interval;
+                                }
+                            }
+                            ++rpi_pos;
                         }
-                        ++rpi_pos;
+                        ++dtk_pos;
                     }
+                }
+                capture = captures.read(RPI_SERIALISE_SIZE);
+            }
+
+            captures.close();
+
+            // Remove empty dtks and transfer actuals
+            int dtk_pos = 0;
+            while (dtk_pos < probables.size()) {
+                if (actuals[dtk_pos].size() > 0) {
+                    probables[dtk_pos].m_rpis = actuals[dtk_pos];
                     ++dtk_pos;
                 }
-            }
-            capture = captures.read(RPI_SERIALISE_SIZE);
-        }
-
-        // Remove empty dtks and transfer actuals
-        int dtk_pos = 0;
-        while (dtk_pos < probables.size()) {
-            if (actuals[dtk_pos].size() > 0) {
-                probables[dtk_pos].m_rpis = actuals[dtk_pos];
-                ++dtk_pos;
-            }
-            else{
-                probables.removeAt(dtk_pos);
-                actuals.removeAt(dtk_pos);
+                else{
+                    probables.removeAt(dtk_pos);
+                    actuals.removeAt(dtk_pos);
+                }
             }
         }
-    }
-    else {
-        qDebug() << "Error opening data file: " << captures.fileName();
-    }
+        else {
+            qDebug() << "Error opening data file: " << captures.fileName();
+        }
 
+        m_contactsMutex.unlock();
+    }
     qDebug() << "Actuals size: " << probables.size();
 
     return probables;
@@ -186,10 +199,15 @@ void DayStorage::addContact(ctinterval interval, const QByteArray &rpi, const QB
 
     data = dataItem.serialise();
     if (!data.isEmpty()) {
+        m_contactsMutex.lock();
         qDebug() << "Outputting to file: " << m_contacts.fileName();
         m_contacts.write(data);
+        m_contactsMutex.unlock();
+
+        m_filterMutex.lock();
         m_filter->add(rpi);
         m_filter_changed = true;
+        m_filterMutex.unlock();
     }
     else {
         qDebug() << "Contact could not be stored: incorrect data size";
@@ -205,6 +223,7 @@ void DayStorage::load()
     QString folder = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/contacts";
     dir.mkpath(folder);
 
+    m_contactsMutex.lock();
     leafname = QStringLiteral("%1.dat");
     leafname = leafname.arg(m_day, 8, 16, QLatin1Char('0'));
     m_contacts.setFileName(folder + "/" + leafname);
@@ -215,7 +234,9 @@ void DayStorage::load()
     else {
         qDebug() << "Error opening file to write: " << m_contacts.fileName();
     }
+    m_contactsMutex.unlock();
 
+    m_filterMutex.lock();
     // Save out the old bloom filter
     if (m_filter) {
         m_filter->save();
@@ -230,30 +251,37 @@ void DayStorage::load()
         m_filter->clear(BLOOM_FILTER_SIZE, BLOOM_FILTER_HASHES);
         m_filter->setDay(m_day);
     }
+    m_filterMutex.unlock();
 }
 
 void DayStorage::save()
 {
+    m_filterMutex.lock();
     if (m_filter_changed) {
         // Write out the bloom filter
         m_filter->save();
         m_filter_changed = false;
     }
+    m_filterMutex.unlock();
 }
 
 bool DayStorage::probableMatch(const QByteArray &rpi)
 {
+    QMutexLocker locker(&m_filterMutex);
     return m_filter->test(rpi);
 }
 
-quint32 DayStorage::dayNumber() const
+quint32 DayStorage::dayNumber()
 {
+    QMutexLocker locker(&m_contactsMutex);
     return m_day;
 }
 
 void DayStorage::dumpData()
 {
     bool result;
+
+    m_contactsMutex.lock();
     m_contacts.seek(0);
     QByteArray read = m_contacts.read(RPI_SERIALISE_SIZE);
     while (!read.isEmpty()) {
@@ -264,5 +292,6 @@ void DayStorage::dumpData()
         }
         read = m_contacts.read(RPI_SERIALISE_SIZE);
     }
+    m_contactsMutex.unlock();
 }
 

--- a/contracd/src/daystorage.h
+++ b/contracd/src/daystorage.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QFile>
+#include <QMutex>
 
 #include "contactmatch.h"
 #include "diagnosiskey.h"
@@ -13,7 +14,7 @@ class DayStorage : public QObject
 {
     Q_OBJECT
 public:
-    explicit DayStorage(quint32 day, QObject * parent);
+    explicit DayStorage(quint32 day, QObject * parent = nullptr);
     ~DayStorage();
 
     QList<RpiDataItem> findRpiMatches(QList<QByteArray> const &rpis);
@@ -22,7 +23,7 @@ public:
     void addContact(ctinterval interval, const QByteArray &rpi, const QByteArray &aem, qint16 rssi);
     void load();
     void save();
-    quint32 dayNumber() const;
+    quint32 dayNumber();
 
     void dumpData();
 
@@ -34,6 +35,8 @@ private:
     QFile m_contacts;
     BloomFilter *m_filter;
     bool m_filter_changed;
+    QMutex m_contactsMutex;
+    QMutex m_filterMutex;
 };
 
 #endif // DAYSTORAGE_H

--- a/contracd/src/dbusinterface.cpp
+++ b/contracd/src/dbusinterface.cpp
@@ -27,6 +27,7 @@ DBusInterface::DBusInterface(QObject *parent)
     connect(&m_exposureNotification, &ExposureNotification::beaconReceived, this, &DBusInterface::incrementReceiveCount);
     connect(&m_exposureNotification, &ExposureNotification::isBusyChanged, this, &DBusInterface::isBusyChanged);
     connect(&m_exposureNotification, &ExposureNotification::actionExposureStateUpdated, this, &DBusInterface::actionExposureStateUpdated);
+    connect(&m_exposureNotification, &ExposureNotification::exposureStateChanged, this, &DBusInterface::exposureStateChanged);
 
     connect(&settings, &Settings::txPowerChanged, this, &DBusInterface::txPowerChanged);
     connect(&settings, &Settings::rssiCorrectionChanged, this, &DBusInterface::rssiCorrectionChanged);
@@ -87,10 +88,10 @@ void DBusInterface::stop()
     m_exposureNotification.stop();
 }
 
-ExposureNotification::Status DBusInterface::status() const
+qint32 DBusInterface::status() const
 {
     qDebug() << "CONTRAC: statis()";
-    return m_exposureNotification.status();
+    return qint32(m_exposureNotification.status());
 }
 
 bool DBusInterface::isEnabled() const
@@ -209,5 +210,10 @@ void DBusInterface::setRssiCorrection(qint32 rssiCorrection)
 {
     rssiCorrection = qBound(INT8_MIN, rssiCorrection, INT8_MAX);
     Settings::getInstance().setRssiCorrection(qint8(rssiCorrection));
+}
+
+qint32 DBusInterface::exposureState(QString const token)
+{
+    return qint32(m_exposureNotification.exposureState(token));
 }
 

--- a/contracd/src/dbusinterface.cpp
+++ b/contracd/src/dbusinterface.cpp
@@ -212,8 +212,12 @@ void DBusInterface::setRssiCorrection(qint32 rssiCorrection)
     Settings::getInstance().setRssiCorrection(qint8(rssiCorrection));
 }
 
-qint32 DBusInterface::exposureState(QString const token)
+qint32 DBusInterface::exposureState(QString const token) const
 {
     return qint32(m_exposureNotification.exposureState(token));
 }
 
+QDateTime DBusInterface::lastProcessTime(QString const token) const
+{
+    return m_exposureNotification.lastProcessTime(token);
+}

--- a/contracd/src/dbusinterface.h
+++ b/contracd/src/dbusinterface.h
@@ -14,7 +14,7 @@ class DBusInterface : public QObject
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", SERVICE_NAME)
 
-    Q_PROPERTY(ExposureNotification::Status status READ status NOTIFY statusChanged)
+    Q_PROPERTY(qint32 status READ status NOTIFY statusChanged)
     Q_PROPERTY(bool isEnabled READ isEnabled NOTIFY isEnabledChanged)
     Q_PROPERTY(quint32 maxDiagnosisKeys READ maxDiagnosisKeys CONSTANT)
 
@@ -29,7 +29,7 @@ public:
     explicit DBusInterface(QObject *parent = nullptr);
     ~DBusInterface();
 
-    Q_INVOKABLE ExposureNotification::Status status() const;
+    Q_INVOKABLE qint32 status() const;
     Q_INVOKABLE bool isEnabled() const;
     Q_INVOKABLE quint32 maxDiagnosisKeys() const;
 
@@ -43,6 +43,7 @@ public:
     Q_INVOKABLE void resetAllData();
 
     // Non-standard additions
+    Q_INVOKABLE qint32 exposureState(QString const token);
     Q_INVOKABLE quint32 receivedCount() const;
     Q_INVOKABLE quint32 sentCount() const;
     Q_INVOKABLE bool isBusy() const;
@@ -54,7 +55,7 @@ public:
 signals:
     void statusChanged();
     void isEnabledChanged();
-    void actionExposureStateUpdated(QString token);
+    void actionExposureStateUpdated(QString const token);
 
     // Non-standard additions
     void receivedCountChanged();
@@ -62,6 +63,7 @@ signals:
     void isBusyChanged();
     void txPowerChanged();
     void rssiCorrectionChanged();
+    void exposureStateChanged(QString const &token);
 
 public slots:
 

--- a/contracd/src/dbusinterface.h
+++ b/contracd/src/dbusinterface.h
@@ -43,7 +43,7 @@ public:
     Q_INVOKABLE void resetAllData();
 
     // Non-standard additions
-    Q_INVOKABLE qint32 exposureState(QString const token);
+    Q_INVOKABLE qint32 exposureState(QString const token) const;
     Q_INVOKABLE quint32 receivedCount() const;
     Q_INVOKABLE quint32 sentCount() const;
     Q_INVOKABLE bool isBusy() const;
@@ -51,6 +51,7 @@ public:
     Q_INVOKABLE qint32 rssiCorrection() const;
     Q_INVOKABLE void setTxPower(qint32 txPower);
     Q_INVOKABLE void setRssiCorrection(qint32 rssiCorrection);
+    Q_INVOKABLE QDateTime lastProcessTime(QString const token) const;
 
 signals:
     void statusChanged();

--- a/contracd/src/dbusinterface.h
+++ b/contracd/src/dbusinterface.h
@@ -37,8 +37,8 @@ public:
     Q_INVOKABLE void stop();
     Q_INVOKABLE QList<TemporaryExposureKey> getTemporaryExposureKeyHistory();
     Q_INVOKABLE void provideDiagnosisKeys(QStringList const &keyFiles, ExposureConfiguration const &configuration, QString token);
-    Q_INVOKABLE ExposureSummary getExposureSummary(QString const &token) const;
-    Q_INVOKABLE QList<ExposureInformation> getExposureInformation(QString const &token) const;
+    Q_INVOKABLE ExposureSummary getExposureSummary(QString const &token);
+    Q_INVOKABLE QList<ExposureInformation> getExposureInformation(QString const &token);
     Q_INVOKABLE quint32 getMaxDiagnosisKeys() const;
     Q_INVOKABLE void resetAllData();
 
@@ -54,6 +54,7 @@ public:
 signals:
     void statusChanged();
     void isEnabledChanged();
+    void actionExposureStateUpdated(QString token);
 
     // Non-standard additions
     void receivedCountChanged();

--- a/contracd/src/exposurenotification.cpp
+++ b/contracd/src/exposurenotification.cpp
@@ -1,7 +1,9 @@
 #include <QList>
 #include <QDebug>
+#include <QRunnable>
+#include <QThreadPool>
+#include <QCoreApplication>
 #include <string.h>
-#include <math.h>
 
 #include "temporaryexposurekey.h"
 #include "contrac.pb.h"
@@ -9,6 +11,7 @@
 #include "contactinterval.h"
 #include "exposuresummary.h"
 #include "settings.h"
+#include "providediagnostickeys.h"
 
 #include "exposurenotification.h"
 #include "exposurenotification_p.h"
@@ -16,62 +19,6 @@
 #define MAX_DIAGNOSIS_KEYS (1024)
 // The spaces are intentional, to pad to 16 bytes
 #define EXPORT_BIN_HEADER QLatin1String("EK Export v1    ")
-
-// In milliseconds
-#define CONTIGUOUS_PERIOD_THRESHOLD (10 * 60 * 1000)
-
-namespace {
-
-inline qint32 checkLowerThreshold(qint32 thresholds[8], QList<qint32> scores, qint32 value)
-{
-    qint8  pos = 7;
-    while ((pos > 0) && (value < thresholds[pos - 1])) {
-        --pos;
-    }
-
-    return scores[pos];
-}
-
-inline qint32 checkGreaterThreshold(qint32 thresholds[8], QList<qint32> scores, qint32 value)
-{
-    qint8 pos = 7;
-    while ((pos > 0) && (value > thresholds[pos - 1])) {
-        --pos;
-    }
-
-    return scores[pos];
-}
-
-template<class T>
-inline T clamp(T value, T min, T max)
-{
-    if (value < min) {
-        value = min;
-    }
-    else {
-        if (value > max) {
-            value = max;
-        }
-    }
-    return value;
-}
-
-inline qint32 attenuationCalculation(qint16 rssiMeasured, qint8 rssiCorrection, qint8 txPower)
-{
-    // Attenuation = TX_power - (RSSI_measured + RSSI_correction)
-    // See https://developers.google.com/android/exposure-notifications/ble-attenuation-overview
-    qint32 attenuation;
-
-    attenuation = txPower - (rssiMeasured + rssiCorrection);
-
-    return attenuation;
-}
-
-inline bool compareIntervals(RpiDataItem const &rpi1, RpiDataItem const & rpi2) {
-    return rpi1.m_interval < rpi2.m_interval;
-}
-
-}
 
 ExposureNotificationPrivate::ExposureNotificationPrivate(ExposureNotification *q)
     : QObject(q)
@@ -112,6 +59,8 @@ ExposureNotificationPrivate::ExposureNotificationPrivate(ExposureNotification *q
     q_ptr->connect(m_scanner, &BleScanner::beaconDiscovered, q_ptr, &ExposureNotification::beaconDiscovered);
     q_ptr->connect(m_scanner, &BleScanner::scanChanged, this, &ExposureNotificationPrivate::scanChanged);
     q_ptr->connect(m_scanner, &BleScanner::busyChanged, q_ptr, &ExposureNotification::isBusyChanged);
+
+    connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, this, &ExposureNotificationPrivate::terminating, Qt::DirectConnection);
 }
 
 ExposureNotificationPrivate::~ExposureNotificationPrivate()
@@ -218,190 +167,17 @@ void ExposureNotification::provideDiagnosisKeys(QVector<QString> const &keyFiles
 {
     Q_D(ExposureNotification);
 
-    bool result;
-    diagnosis::TemporaryExposureKeyExport keyExport;
-    int pos;
-    QList<DiagnosisKey> diagnosisKeys[DAYS_TO_STORE];
-    QList<ExposureInformation> exposureInfoList;
-
     d->m_contrac->updateKeys();
+    qint8 rssiCorrection = Settings::getInstance().rssiCorrection();
 
-    // Values will accumulate
-    // We assume the same keyFiles won't be provided more than once
-    if (d->m_exposures.contains(token)) {
-        exposureInfoList = d->m_exposures.value(token);
-    }
+    // This is a potentiallyl very long-running process, so we execute it in a background thread
+    // The actionExposureStateUpdated signal is sent out to the app when the process completes
+    // The task is deleted automatically when the QRunnable completes
+    ProvideDiagnosticKeys * task = new ProvideDiagnosticKeys(d, keyFiles, configuration, token, rssiCorrection);
+    connect(task, &ProvideDiagnosticKeys::actionExposureStateUpdated, this, &ExposureNotification::actionExposureStateUpdated);
+    connect(d, &ExposureNotificationPrivate::terminating, task, &ProvideDiagnosticKeys::requestTerminate, Qt::DirectConnection);
 
-    for (QString const &file : keyFiles) {
-        // TODO: Check region
-        // TODO: Check batch numbering
-        // TODO: Check start/end timestamps
-        result = ExposureNotificationPrivate::loadDiagnosisKeys(file, &keyExport);
-        if (result) {
-            for(pos = 0; pos < keyExport.keys_size(); ++pos) {
-                diagnosis::TemporaryExposureKey const &key = keyExport.keys(pos);
-                QByteArray dtk(key.key_data().data(), static_cast<int>(key.key_data().length()));
-                DiagnosisKey diagnosisKey(dtk, static_cast<DiagnosisKey::RiskLevel>(key.transmission_risk_level()), static_cast<quint32>(key.rolling_start_interval_number()), static_cast<quint32>(key.rolling_period()));
-                qint64 day = static_cast<quint32>(key.rolling_start_interval_number() / 144) - d->m_contrac->dayNumber();
-                if (day >= 0 && day < DAYS_TO_STORE) {
-                    diagnosisKeys[day].append(diagnosisKey);
-                }
-
-            }
-        }
-        else {
-            qDebug() << "Error loading diagnosis key file: " << file;
-        }
-    }
-
-    for (quint32 day = 0; day < DAYS_TO_STORE; ++day) {
-        if (diagnosisKeys[day].length() > 0) {
-            quint32 const dayNumber = d->m_contrac->dayNumber() + day;
-            QList<ContactMatch> matches = d->m_contacts->findDtkMatches(dayNumber, diagnosisKeys[day]);
-
-            qint32 days_ago = static_cast<qint32>(dayNumber) - static_cast<qint32>(d->m_contrac->dayNumber());
-            exposureInfoList.append(d->aggregateExposureData(dayNumber, configuration, matches, days_ago));
-        }
-    }
-
-    // Replace the previous values with the accumulated total
-    d->m_exposures.insert(token, exposureInfoList);
-}
-
-QList<ExposureInformation> ExposureNotificationPrivate::aggregateExposureData(quint32 dayNumber, ExposureConfiguration const &configuration, QList<ContactMatch> matches, qint32 const days_ago)
-{
-    QList<ExposureInformation> exposures;
-    qint32 attenuationThreshold[2];
-    attenuationThreshold[0] = configuration.durationAtAttenuationThresholds()[0];
-    attenuationThreshold[1] = configuration.durationAtAttenuationThresholds()[1];
-
-    qint32 transmissionRisk;
-    qint32 totalDuration;
-    //qint32 days_ago;
-    qint32 attenuationValue;
-
-    Metadata metadata;
-    qint8 rssiCorrection;
-    qint8 txPower;
-    qint32 attenuation;
-
-    rssiCorrection = Settings::getInstance().rssiCorrection();
-
-    for (ContactMatch match : matches) {
-        metadata.setDtk(match.m_dtk->m_dtk);
-
-        // The aggregation process assumes that rpi intervals are increasing
-        // So order the RPIs if necessary to ensure this
-        // This is just for safety, by far the most likely situation is that they'll already be ordered
-        if (!std::is_sorted(match.m_rpis.begin(), match.m_rpis.end(), compareIntervals)) {
-            qDebug() << "Reordering RPIs to have increasing interval values";
-            std::sort(match.m_rpis.begin(), match.m_rpis.end(), compareIntervals);
-        }
-
-        int rpi_pos = 0;
-        qDebug() << "Aggregating data for rpi matches:" << match.m_rpis.size();
-        while (rpi_pos < match.m_rpis.size()) {
-            ExposureInformation exposure;
-
-            quint64 const dateMillisSinceEpoch = dayNumber * 24 * 60 * 60 * 1000;
-            exposure.setDateMillisSinceEpoch(dateMillisSinceEpoch);
-            transmissionRisk = static_cast<qint32>(match.m_dtk->m_transmissionRiskLevel);
-            exposure.setTransmissionRiskLevel(transmissionRisk);
-
-            qint64 interval = match.m_rpis[rpi_pos].m_interval;
-            totalDuration = 0;
-            qint32 totalRiskScore;
-            qint32 attenuationDurations[3] = {0, 0, 0};
-            qint64 attenuationSum = 0;
-            while (rpi_pos < match.m_rpis.size() && (match.m_rpis[rpi_pos].m_interval < interval + (CONTIGUOUS_PERIOD_THRESHOLD / CTINTERVAL_DURATION) + 1)) {
-                RpiDataItem const &rpi = match.m_rpis[rpi_pos];
-                // The timeDelta value should be measured in minutes and rounded upwards
-                qint64 timeDelta = qint64(ceil((qint64(1 + rpi.m_interval) - interval) / double(60 * 1000 / CTINTERVAL_DURATION)));
-                // Make use of the txPower stored in the AEM
-                metadata.setEncryptedMetadata(rpi.m_aem);
-                metadata.setRpi(rpi.m_rpi);
-                txPower = metadata.txPower();
-                // The metadata must also be valid
-                if (metadata.valid()) {
-                    attenuation = attenuationCalculation(rpi.m_rssi, rssiCorrection, txPower);
-
-                    // Attenuation durations in minutes
-                    // From the specification:
-                    // "Array of durations in minutes at certain radio signal attenuations."
-                    if (attenuation < attenuationThreshold[0]) {
-                        attenuationDurations[0] += timeDelta;
-                    }
-                    else {
-                        if (attenuation < attenuationThreshold[1]) {
-                            attenuationDurations[1] += timeDelta;
-                        }
-                        else {
-                            attenuationDurations[2] += timeDelta;
-                        }
-                    }
-                    attenuationSum += (attenuation * timeDelta);
-
-                    interval = rpi.m_interval;
-                    totalDuration += timeDelta;
-                }
-                else {
-                    qDebug() << "Invalid metadata";
-                }
-
-                ++rpi_pos;
-            }
-            // Duration to the nearest 5 minutes
-            // From the specification:
-            // "Length of exposure in 5 minute increments, with a 30 minute maximum."
-            qint32 durationMinutes = 5 * qint32(ceil(totalDuration / 5.0));
-            if (durationMinutes > 30) {
-                durationMinutes = 30;
-            }
-            exposure.setDurationMinutes(durationMinutes);
-            QList<qint32> attenuationDurationList;
-            attenuationDurationList.append(attenuationDurations[0]);
-            attenuationDurationList.append(attenuationDurations[1]);
-            attenuationDurationList.append(attenuationDurations[2]);
-            exposure.setAttenuationDurations(attenuationDurationList);
-            attenuationValue = totalDuration > 0 ? qint32(attenuationSum / totalDuration) : 0;
-            exposure.setAttenuationValue(attenuationValue);
-
-            // We no longer calculate days_ago to allow unit tests to work correctly
-            //days_ago = static_cast<qint32>(dayNumber) - static_cast<qint32>(m_contrac->dayNumber());
-            totalRiskScore = calculateRiskScore(configuration, transmissionRisk, totalDuration, days_ago, attenuationValue);
-
-            exposure.setTotalRiskScore(totalRiskScore);
-
-            exposures.append(exposure);
-        }
-    }
-
-    return exposures;
-}
-
-qint32 ExposureNotificationPrivate::calculateRiskScore(ExposureConfiguration const &configuration, qint32 transmissionRisk, qint32 duration, qint32 days_ago, qint32 attenuationValue)
-{
-    qint32 riskScore;
-    qint32 attenuationScore;
-    qint32 daysSinceLastExposureScore;
-    qint32 durationScore;
-    qint32 transmissionRiskScore;
-    qint8 pos;
-
-    qint32 attenuationThresholds[8] = {73, 63, 51, 33, 27, 15, 10};
-    qint32 daysThresholds[8] = {14, 12, 10, 8, 6, 4, 2};
-    qint32 durationThreshold[8] = {1, 6, 11, 16, 21, 26, 31};
-
-    attenuationScore = checkGreaterThreshold(attenuationThresholds, configuration.attenuationScores(), attenuationValue);
-    daysSinceLastExposureScore = checkGreaterThreshold(daysThresholds, configuration.daysSinceLastExposureScores(), days_ago);
-    durationScore = checkLowerThreshold(durationThreshold, configuration.durationScores(), duration);
-
-    pos = clamp(static_cast<qint8>(transmissionRisk), static_cast<qint8>(0), static_cast<qint8>(7));
-    transmissionRiskScore = configuration.transmissionRiskScores()[pos];
-
-    riskScore = attenuationScore * daysSinceLastExposureScore * durationScore * transmissionRiskScore;
-
-    return riskScore;
+    QThreadPool::globalInstance()->start(task);
 }
 
 bool ExposureNotificationPrivate::loadDiagnosisKeys(QString const &keyFile, diagnosis::TemporaryExposureKeyExport *keyExport)
@@ -430,7 +206,9 @@ bool ExposureNotificationPrivate::loadDiagnosisKeys(QString const &keyFile, diag
 
     if (result) {
         ZipIStreamBuffer streambuf(quazip, "export.bin");
-        qDebug() << "Stream is good: " << streambuf.success();
+        if (!streambuf.success()) {
+            qDebug() << "Zip stream creation failed";
+        }
         std::istream stream(&streambuf);
         QByteArray header(16, '\0');
         stream.read(header.data(), 16);
@@ -443,11 +221,7 @@ bool ExposureNotificationPrivate::loadDiagnosisKeys(QString const &keyFile, diag
     }
 
     if (result) {
-        qDebug() << "Diagnosis file region: " << keyExport->region().data();
-        qDebug() << "Diagnosis file start timestamp: " << keyExport->start_timestamp();
-        qDebug() << "Diagnosis file end timestamp: " << keyExport->end_timestamp();
-        qDebug() << "Diagnosis file keys: " << keyExport->keys().size();
-        qDebug() << "Diagnosis file verification key: " << keyExport->signature_infos().size();
+        qDebug() << "Diagnosis file: " << keyExport->keys().size() <<"keys;" << keyExport->region().data() << keyExport->start_timestamp() << "-" << keyExport->end_timestamp();
     }
     else {
         qDebug() << "TemporaryExposureKeyExport proto file failed to load";
@@ -467,9 +241,9 @@ void ExposureNotificationPrivate::scanChanged()
     emit q->isEnabledChanged();
 }
 
-ExposureSummary ExposureNotification::getExposureSummary(QString const &token) const
+ExposureSummary ExposureNotification::getExposureSummary(QString const &token)
 {
-    Q_D(const ExposureNotification);
+    Q_D(ExposureNotification);
 
     QList<ExposureInformation> exposureInfoList;
     ExposureSummary summary;
@@ -479,6 +253,7 @@ ExposureSummary ExposureNotification::getExposureSummary(QString const &token) c
     qint32 summationRiskScore;
     QList<qint32> attenuationDurations = QList<qint32>({0, 0, 0});
 
+    d->m_exposureMutex.lock();
     if (d->m_exposures.contains(token)) {
         exposureInfoList = d->m_exposures.value(token);
 
@@ -513,13 +288,15 @@ ExposureSummary ExposureNotification::getExposureSummary(QString const &token) c
         summary.setAttenuationDurations(attenuationDurations);
         summary.setSummationRiskScore(summationRiskScore);
     }
+    d->m_exposureMutex.unlock();
 
     return summary;
 }
 
-QList<ExposureInformation> ExposureNotification::getExposureInformation(QString const &token) const
+QList<ExposureInformation> ExposureNotification::getExposureInformation(QString const &token)
 {
-    Q_D(const ExposureNotification);
+    Q_D(ExposureNotification);
+    QMutexLocker locker(&(d->m_exposureMutex));
 
     return d->m_exposures.value(token, QList<ExposureInformation>());
 }

--- a/contracd/src/exposurenotification.h
+++ b/contracd/src/exposurenotification.h
@@ -51,8 +51,8 @@ public:
     Q_INVOKABLE void stop();
     Q_INVOKABLE QList<TemporaryExposureKey> getTemporaryExposureKeyHistory();
     Q_INVOKABLE void provideDiagnosisKeys(QVector<QString> const &keyFiles, ExposureConfiguration const &configuration, QString token);
-    Q_INVOKABLE ExposureSummary getExposureSummary(QString const &token) const;
-    Q_INVOKABLE QList<ExposureInformation> getExposureInformation(QString const &token) const;
+    Q_INVOKABLE ExposureSummary getExposureSummary(QString const &token);
+    Q_INVOKABLE QList<ExposureInformation> getExposureInformation(QString const &token);
     Q_INVOKABLE quint32 getMaxDiagnosisKeys() const;
     Q_INVOKABLE void resetAllData();
 
@@ -63,6 +63,8 @@ signals:
 
     void beaconSent();
     void beaconReceived();
+
+    void actionExposureStateUpdated(QString token);
 
 public slots:
     void beaconDiscovered(const QString &address, const QByteArray &data, qint16 rssi);

--- a/contracd/src/exposurenotification.h
+++ b/contracd/src/exposurenotification.h
@@ -44,8 +44,9 @@ public:
 
     enum ExposureState
     {
-        Idle = 0,
-        Working
+        None = 0,
+        Processing,
+        Available
     };
     Q_ENUM(ExposureState)
 
@@ -58,11 +59,12 @@ public:
     Q_INVOKABLE void stop();
     Q_INVOKABLE QList<TemporaryExposureKey> getTemporaryExposureKeyHistory();
     Q_INVOKABLE void provideDiagnosisKeys(QVector<QString> const &keyFiles, ExposureConfiguration const &configuration, QString token);
-    Q_INVOKABLE ExposureSummary getExposureSummary(QString const &token);
-    Q_INVOKABLE QList<ExposureInformation> getExposureInformation(QString const &token);
+    Q_INVOKABLE ExposureSummary getExposureSummary(QString const &token) const;
+    Q_INVOKABLE QList<ExposureInformation> getExposureInformation(QString const &token) const;
     Q_INVOKABLE quint32 getMaxDiagnosisKeys() const;
     Q_INVOKABLE void resetAllData();
-    Q_INVOKABLE ExposureState exposureState(QString const &token);
+    Q_INVOKABLE ExposureState exposureState(QString const &token) const;
+    Q_INVOKABLE QDateTime lastProcessTime(QString const &token) const;
 
 signals:
     void statusChanged();

--- a/contracd/src/exposurenotification.h
+++ b/contracd/src/exposurenotification.h
@@ -22,7 +22,6 @@ class ExposureNotificationPrivate;
 class ExposureNotification : public QObject
 {
     Q_OBJECT
-    Q_ENUMS(Status)
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
     Q_PROPERTY(bool isEnabled READ isEnabled NOTIFY isEnabledChanged)
     Q_PROPERTY(bool isBusy READ isBusy NOTIFY isBusyChanged)
@@ -41,6 +40,14 @@ public:
         FailedInsufficientStorage,
         FailedInternal
     };
+    Q_ENUM(Status)
+
+    enum ExposureState
+    {
+        Idle = 0,
+        Working
+    };
+    Q_ENUM(ExposureState)
 
     Status status() const;
     bool isEnabled() const;
@@ -55,6 +62,7 @@ public:
     Q_INVOKABLE QList<ExposureInformation> getExposureInformation(QString const &token);
     Q_INVOKABLE quint32 getMaxDiagnosisKeys() const;
     Q_INVOKABLE void resetAllData();
+    Q_INVOKABLE ExposureState exposureState(QString const &token);
 
 signals:
     void statusChanged();
@@ -64,7 +72,8 @@ signals:
     void beaconSent();
     void beaconReceived();
 
-    void actionExposureStateUpdated(QString token);
+    void actionExposureStateUpdated(QString const &token);
+    void exposureStateChanged(QString const &token);
 
 public slots:
     void beaconDiscovered(const QString &address, const QByteArray &data, qint16 rssi);

--- a/contracd/src/exposurenotification_p.h
+++ b/contracd/src/exposurenotification_p.h
@@ -14,6 +14,8 @@ namespace diagnosis {
 class TemporaryExposureKeyExport;
 } // namespace diagnosis
 
+class ProvideDiagnosticKeys;
+
 class ExposureNotificationPrivate : public QObject
 {
     Q_OBJECT
@@ -30,6 +32,7 @@ private:
 
 public slots:
     void scanChanged();
+    void taskTerminating(QString const token);
 
 signals:
     void terminating();
@@ -44,6 +47,7 @@ public:
     Metadata m_metadata;
     QTimer m_intervalUpdate;
     QMutex m_exposureMutex;
+    QMap<QString, ProvideDiagnosticKeys *> m_runningTasks;
 };
 
 #endif // EXPOSURENOTIFICATION_P_H

--- a/contracd/src/exposurenotification_p.h
+++ b/contracd/src/exposurenotification_p.h
@@ -32,7 +32,7 @@ private:
 
 public slots:
     void scanChanged();
-    void taskTerminating(QString const token);
+    void taskFinished(QString const token);
 
 signals:
     void terminating();
@@ -46,8 +46,8 @@ public:
     ContactStorage *m_contacts;
     Metadata m_metadata;
     QTimer m_intervalUpdate;
-    QMutex m_exposureMutex;
     QMap<QString, ProvideDiagnosticKeys *> m_runningTasks;
+    QMap<QString, QDateTime> m_lastProcessTime;
 };
 
 #endif // EXPOSURENOTIFICATION_P_H

--- a/contracd/src/exposurenotification_p.h
+++ b/contracd/src/exposurenotification_p.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QTimer>
+#include <QMutex>
 
 #include "exposureinformation.h"
 #include "contrac.h"
@@ -21,8 +22,6 @@ public:
     ~ExposureNotificationPrivate();
 
     static bool loadDiagnosisKeys(QString const &keyFile, diagnosis::TemporaryExposureKeyExport * keyExport);
-    static QList<ExposureInformation> aggregateExposureData(quint32 dayNumber, ExposureConfiguration const &configuration, QList<ContactMatch> matches, qint32 const days_ago);
-    static qint32 calculateRiskScore(ExposureConfiguration const &configuration, qint32 transmissionRisk, qint32 duration, qint32 days_ago, qint32 attenuationValue);
 
 private:
     ExposureNotification *q_ptr;
@@ -31,6 +30,9 @@ private:
 
 public slots:
     void scanChanged();
+
+signals:
+    void terminating();
 
 public:
     QMap<QString, QList<ExposureInformation>> m_exposures;
@@ -41,6 +43,7 @@ public:
     ContactStorage *m_contacts;
     Metadata m_metadata;
     QTimer m_intervalUpdate;
+    QMutex m_exposureMutex;
 };
 
 #endif // EXPOSURENOTIFICATION_P_H

--- a/contracd/src/providediagnostickeys.cpp
+++ b/contracd/src/providediagnostickeys.cpp
@@ -287,6 +287,8 @@ void ProvideDiagnosticKeys::run()
         terminate = shouldTerminate();
     }
 
+    emit terminating(m_token);
+
     if (!terminate) {
         // Replace the previous values with the accumulated total
         m_d->m_exposureMutex.lock();

--- a/contracd/src/providediagnostickeys.cpp
+++ b/contracd/src/providediagnostickeys.cpp
@@ -1,0 +1,318 @@
+#include <QDebug>
+#include <math.h>
+#include <QMutexLocker>
+
+#include "exposurenotification_p.h"
+#include "contrac.pb.h"
+
+#include "providediagnostickeys.h"
+
+// In milliseconds
+#define CONTIGUOUS_PERIOD_THRESHOLD (10 * 60 * 1000)
+
+#define MAX_BATCH_SIZE (1024)
+
+namespace { // anonymous namespace
+
+inline qint32 attenuationCalculation(qint16 rssiMeasured, qint8 rssiCorrection, qint8 txPower)
+{
+    // Attenuation = TX_power - (RSSI_measured + RSSI_correction)
+    // See https://developers.google.com/android/exposure-notifications/ble-attenuation-overview
+    qint32 attenuation;
+
+    attenuation = txPower - (rssiMeasured + rssiCorrection);
+
+    return attenuation;
+}
+
+inline qint32 checkLowerThreshold(qint32 thresholds[8], QList<qint32> scores, qint32 value)
+{
+    qint8  pos = 7;
+    while ((pos > 0) && (value < thresholds[pos - 1])) {
+        --pos;
+    }
+
+    return scores[pos];
+}
+
+inline qint32 checkGreaterThreshold(qint32 thresholds[8], QList<qint32> scores, qint32 value)
+{
+    qint8 pos = 7;
+    while ((pos > 0) && (value > thresholds[pos - 1])) {
+        --pos;
+    }
+
+    return scores[pos];
+}
+
+template<class T>
+inline T clamp(T value, T min, T max)
+{
+    if (value < min) {
+        value = min;
+    }
+    else {
+        if (value > max) {
+            value = max;
+        }
+    }
+    return value;
+}
+
+inline bool compareIntervals(RpiDataItem const &rpi1, RpiDataItem const & rpi2)
+{
+    return rpi1.m_interval < rpi2.m_interval;
+}
+
+qint32 calculateRiskScore(ExposureConfiguration const &configuration, qint32 transmissionRisk, qint32 duration, qint32 days_ago, qint32 attenuationValue)
+{
+    qint32 riskScore;
+    qint32 attenuationScore;
+    qint32 daysSinceLastExposureScore;
+    qint32 durationScore;
+    qint32 transmissionRiskScore;
+    qint8 pos;
+
+    qint32 attenuationThresholds[8] = {73, 63, 51, 33, 27, 15, 10};
+    qint32 daysThresholds[8] = {14, 12, 10, 8, 6, 4, 2};
+    qint32 durationThreshold[8] = {1, 6, 11, 16, 21, 26, 31};
+
+    attenuationScore = checkGreaterThreshold(attenuationThresholds, configuration.attenuationScores(), attenuationValue);
+    daysSinceLastExposureScore = checkGreaterThreshold(daysThresholds, configuration.daysSinceLastExposureScores(), days_ago);
+    durationScore = checkLowerThreshold(durationThreshold, configuration.durationScores(), duration);
+
+    pos = clamp(static_cast<qint8>(transmissionRisk), static_cast<qint8>(0), static_cast<qint8>(7));
+    transmissionRiskScore = configuration.transmissionRiskScores()[pos];
+
+    riskScore = attenuationScore * daysSinceLastExposureScore * durationScore * transmissionRiskScore;
+
+    return riskScore;
+}
+
+} // anonymous namespace
+
+QList<ExposureInformation> ProvideDiagnosticKeys::aggregateExposureData(quint32 dayNumber, ExposureConfiguration const &configuration, QList<ContactMatch> matches, qint32 const days_ago) const
+{
+    qDebug() << "MinimumRiskScore: " << configuration.minimumRiskScore();
+    qDebug() << "AttenuationScores: " << configuration.attenuationScores();
+    qDebug() << "DaysSinceLastExposureScores: " << configuration.daysSinceLastExposureScores();
+    qDebug() << "DurationScores: " << configuration.durationScores();
+    qDebug() << "TransmissionRiskScores: " << configuration.transmissionRiskScores();
+    qDebug() << "DurationAtAttenuationThresholds: " << configuration.durationAtAttenuationThresholds();
+
+    QList<ExposureInformation> exposures;
+    qint32 attenuationThreshold[2];
+    attenuationThreshold[0] = configuration.durationAtAttenuationThresholds()[0];
+    attenuationThreshold[1] = configuration.durationAtAttenuationThresholds()[1];
+
+    qint32 transmissionRisk;
+    qint32 totalDuration;
+    //qint32 days_ago;
+    qint32 attenuationValue;
+
+    Metadata metadata;
+    qint8 txPower;
+    qint32 attenuation;
+
+    for (ContactMatch match : matches) {
+        metadata.setDtk(match.m_dtk->m_dtk);
+
+        // The aggregation process assumes that rpi intervals are increasing
+        // So order the RPIs if necessary to ensure this
+        // This is just for safety, by far the most likely situation is that they'll already be ordered
+        if (!std::is_sorted(match.m_rpis.begin(), match.m_rpis.end(), compareIntervals)) {
+            qDebug() << "Reordering RPIs to have increasing interval values";
+            std::sort(match.m_rpis.begin(), match.m_rpis.end(), compareIntervals);
+        }
+
+        int rpi_pos = 0;
+        qDebug() << "Aggregating data for rpi matches:" << match.m_rpis.size();
+        while (rpi_pos < match.m_rpis.size()) {
+            ExposureInformation exposure;
+
+            quint64 const dateMillisSinceEpoch = dayNumber * 24 * 60 * 60 * 1000;
+            exposure.setDateMillisSinceEpoch(dateMillisSinceEpoch);
+            transmissionRisk = static_cast<qint32>(match.m_dtk->m_transmissionRiskLevel);
+            exposure.setTransmissionRiskLevel(transmissionRisk);
+
+            qint64 interval = match.m_rpis[rpi_pos].m_interval;
+            totalDuration = 0;
+            qint32 totalRiskScore;
+            qint32 attenuationDurations[3] = {0, 0, 0};
+            qint64 attenuationSum = 0;
+            while (rpi_pos < match.m_rpis.size() && (match.m_rpis[rpi_pos].m_interval < interval + (CONTIGUOUS_PERIOD_THRESHOLD / CTINTERVAL_DURATION) + 1)) {
+                RpiDataItem const &rpi = match.m_rpis[rpi_pos];
+                // The timeDelta value should be measured in minutes and rounded upwards
+                qint64 timeDelta = qint64(ceil((qint64(1 + rpi.m_interval) - interval) / double(60 * 1000 / CTINTERVAL_DURATION)));
+                // Make use of the txPower stored in the AEM
+                metadata.setEncryptedMetadata(rpi.m_aem);
+                metadata.setRpi(rpi.m_rpi);
+                txPower = metadata.txPower();
+                // The metadata must also be valid
+                if (metadata.valid()) {
+                    attenuation = attenuationCalculation(rpi.m_rssi, m_rssiCorrection, txPower);
+
+                    // Attenuation durations in minutes
+                    // From the specification:
+                    // "Array of durations in minutes at certain radio signal attenuations."
+                    if (attenuation < attenuationThreshold[0]) {
+                        attenuationDurations[0] += timeDelta;
+                    }
+                    else {
+                        if (attenuation < attenuationThreshold[1]) {
+                            attenuationDurations[1] += timeDelta;
+                        }
+                        else {
+                            attenuationDurations[2] += timeDelta;
+                        }
+                    }
+                    attenuationSum += (attenuation * timeDelta);
+
+                    interval = rpi.m_interval;
+                    totalDuration += timeDelta;
+                }
+                else {
+                    qDebug() << "Invalid metadata";
+                }
+
+                ++rpi_pos;
+            }
+            // Duration to the nearest 5 minutes
+            // From the specification:
+            // "Length of exposure in 5 minute increments, with a 30 minute maximum."
+            qint32 durationMinutes = 5 * qint32(ceil(totalDuration / 5.0));
+            if (durationMinutes > 30) {
+                durationMinutes = 30;
+            }
+            exposure.setDurationMinutes(durationMinutes);
+            QList<qint32> attenuationDurationList;
+            attenuationDurationList.append(attenuationDurations[0]);
+            attenuationDurationList.append(attenuationDurations[1]);
+            attenuationDurationList.append(attenuationDurations[2]);
+            exposure.setAttenuationDurations(attenuationDurationList);
+            attenuationValue = totalDuration > 0 ? qint32(attenuationSum / totalDuration) : 0;
+            exposure.setAttenuationValue(attenuationValue);
+
+            // We no longer calculate days_ago to allow unit tests to work correctly
+            //days_ago = static_cast<qint32>(dayNumber) - static_cast<qint32>(m_contrac->dayNumber());
+            totalRiskScore = calculateRiskScore(configuration, transmissionRisk, totalDuration, days_ago, attenuationValue);
+
+            exposure.setTotalRiskScore(totalRiskScore);
+
+            exposures.append(exposure);
+        }
+    }
+
+    return exposures;
+}
+
+ProvideDiagnosticKeys::ProvideDiagnosticKeys(ExposureNotificationPrivate * exposureNotificationPrivate, QVector<QString> const &keyFiles, ExposureConfiguration const &configuration, QString &token, qint8 rssiCorrection)
+    : QObject(exposureNotificationPrivate)
+    , m_d(exposureNotificationPrivate)
+    , m_keyFiles(keyFiles)
+    , m_configuration(configuration)
+    , m_token(token)
+    , m_rssiCorrection(rssiCorrection)
+    , m_terminate(false)
+{
+    m_currentDayNumber = m_d->m_contrac->dayNumber();
+}
+
+void ProvideDiagnosticKeys::run()
+{
+    bool result;
+    int pos;
+    QList<DiagnosisKey> diagnosisKeys[DAYS_TO_STORE];
+    QList<ExposureInformation> exposureInfoList;
+    bool terminate = false;
+
+    // Values will accumulate
+    // We assume the same keyFiles won't be provided more than once
+    m_d->m_exposureMutex.lock();
+    if (m_d->m_exposures.contains(m_token)) {
+        exposureInfoList = m_d->m_exposures.value(m_token);
+    }
+    m_d->m_exposureMutex.unlock();
+
+    for (QVector<QString>::const_iterator iter = m_keyFiles.begin(); (iter != m_keyFiles.end()) && !terminate; ++iter) {
+        QString const &file = *iter;
+        // TODO: Check region
+        // TODO: Check batch numbering
+        // TODO: Check start/end timestamps
+        diagnosis::TemporaryExposureKeyExport keyExport;
+        result = ExposureNotificationPrivate::loadDiagnosisKeys(file, &keyExport);
+        if (result) {
+            for(pos = 0; pos < keyExport.keys_size(); ++pos) {
+                diagnosis::TemporaryExposureKey const &key = keyExport.keys(pos);
+                QByteArray dtk(key.key_data().data(), static_cast<int>(key.key_data().length()));
+                DiagnosisKey diagnosisKey(dtk, static_cast<DiagnosisKey::RiskLevel>(key.transmission_risk_level()), static_cast<quint32>(key.rolling_start_interval_number()), static_cast<quint32>(key.rolling_period()));
+                qint64 day = m_currentDayNumber - (key.rolling_start_interval_number() / 144);
+                if (day >= 0 && day < DAYS_TO_STORE) {
+                    diagnosisKeys[day].append(diagnosisKey);
+                }
+//                else {
+//                    qDebug() << "Day falls outside 14 day range: " << day;
+//                }
+
+            }
+        }
+        else {
+            qDebug() << "Error loading diagnosis key file: " << file;
+        }
+        terminate = shouldTerminate();
+    }
+
+    for (qint32 day = 0; (day < DAYS_TO_STORE) && !terminate; ++day) {
+        qDebug() << "Aggregating day: " << day;
+        if (diagnosisKeys[day].length() > 0) {
+            quint32 const dayNumber = static_cast<quint32>(m_currentDayNumber + day);
+            qDebug() << "Calling findDtkMatches with" << diagnosisKeys[day].count() << " keys";
+
+            QList<ContactMatch> matches;
+            qint32 batchPos = 0;
+            while (batchPos < diagnosisKeys[day].size() && !terminate) {
+                QList<DiagnosisKey> diagnosticKeyBatch;
+                diagnosticKeyBatch = diagnosisKeys[day].mid(batchPos, MAX_BATCH_SIZE);
+                batchPos += MAX_BATCH_SIZE;
+                matches.append(m_d->m_contacts->findDtkMatches(dayNumber, diagnosisKeys[day]));
+                terminate = shouldTerminate();
+            }
+
+            terminate = shouldTerminate();
+            if (!terminate) {
+                qDebug() << "Calling aggregateExposureData with" << matches.count() << "matches";
+                exposureInfoList.append(aggregateExposureData(dayNumber, m_configuration, matches, day));
+            }
+        }
+        terminate = shouldTerminate();
+    }
+
+    if (!terminate) {
+        // Replace the previous values with the accumulated total
+        m_d->m_exposureMutex.lock();
+        m_d->m_exposures.insert(m_token, exposureInfoList);
+        m_d->m_exposureMutex.unlock();
+
+        qDebug() << "Sending actionExposureStateUpdated signal";
+        emit actionExposureStateUpdated(m_token);
+    }
+    else {
+        qDebug() << "ProvideDiagnosticKeys calculation terminated early";
+    }
+}
+
+bool ProvideDiagnosticKeys::shouldTerminate()
+{
+    QMutexLocker locker(&m_terminateMutex);
+
+    return m_terminate;
+}
+
+void ProvideDiagnosticKeys::requestTerminate()
+{
+    qDebug() << "Requesting termination";
+
+    QMutexLocker locker(&m_terminateMutex);
+
+    m_terminate = true;
+}

--- a/contracd/src/providediagnostickeys.h
+++ b/contracd/src/providediagnostickeys.h
@@ -28,7 +28,8 @@ public slots:
     void requestTerminate();
 
 signals:
-    void actionExposureStateUpdated(QString token);
+    void actionExposureStateUpdated(QString const token);
+    void terminating(QString const token);
 
 private:
     ExposureNotificationPrivate * m_d;

--- a/contracd/src/providediagnostickeys.h
+++ b/contracd/src/providediagnostickeys.h
@@ -5,6 +5,7 @@
 #include <QRunnable>
 #include <QVector>
 #include <QMutex>
+#include <QDateTime>
 
 #include "exposureinformation.h"
 #include "contactmatch.h"
@@ -23,13 +24,15 @@ public:
 
     bool shouldTerminate();
     QList<ExposureInformation> aggregateExposureData(quint32 dayNumber, ExposureConfiguration const &configuration, QList<ContactMatch> matches, qint32 const days_ago) const;
+    QDateTime const startTime() const;
+    QList<ExposureInformation> const &exposureInfoList() const;
 
 public slots:
     void requestTerminate();
 
 signals:
     void actionExposureStateUpdated(QString const token);
-    void terminating(QString const token);
+    void taskFinished(QString const token);
 
 private:
     ExposureNotificationPrivate * m_d;
@@ -40,6 +43,8 @@ private:
     qint8 m_rssiCorrection;
     QMutex m_terminateMutex;
     bool m_terminate;
+    QDateTime m_startTime;
+    QList<ExposureInformation> m_exposureInfoList;
 };
 
 #endif // PROVIDEDIAGNOSTICKEYS_H

--- a/contracd/src/providediagnostickeys.h
+++ b/contracd/src/providediagnostickeys.h
@@ -1,0 +1,44 @@
+#ifndef PROVIDEDIAGNOSTICKEYS_H
+#define PROVIDEDIAGNOSTICKEYS_H
+
+#include <QObject>
+#include <QRunnable>
+#include <QVector>
+#include <QMutex>
+
+#include "exposureinformation.h"
+#include "contactmatch.h"
+
+#include "exposureconfiguration.h"
+
+class ExposureNotificationPrivate;
+
+class ProvideDiagnosticKeys : public QObject, public QRunnable
+{
+    Q_OBJECT
+public:
+    ProvideDiagnosticKeys(ExposureNotificationPrivate * exposureNotificationPrivate, QVector<QString> const &keyFiles, ExposureConfiguration const &configuration, QString &token, qint8 rssiCorrection);
+
+    void run() override;
+
+    bool shouldTerminate();
+    QList<ExposureInformation> aggregateExposureData(quint32 dayNumber, ExposureConfiguration const &configuration, QList<ContactMatch> matches, qint32 const days_ago) const;
+
+public slots:
+    void requestTerminate();
+
+signals:
+    void actionExposureStateUpdated(QString token);
+
+private:
+    ExposureNotificationPrivate * m_d;
+    QVector<QString> const m_keyFiles;
+    ExposureConfiguration const m_configuration;
+    QString const m_token;
+    qint64 m_currentDayNumber;
+    qint8 m_rssiCorrection;
+    QMutex m_terminateMutex;
+    bool m_terminate;
+};
+
+#endif // PROVIDEDIAGNOSTICKEYS_H

--- a/qml/harbour-contrac.qml
+++ b/qml/harbour-contrac.qml
@@ -6,9 +6,11 @@ import "pages"
 
 ApplicationWindow
 {
+    id: root
     readonly property bool downloadAvailable: moreThanADayAgo(AppSettings.summaryUpdated)
     property bool updating
-    readonly property bool busy: upload.uploaindg || download.downloading || updating || dbusproxy.isBusy
+    readonly property bool busy: upload.uploading || download.downloading || updating || dbusproxy.isBusy
+    readonly property string token: "abcdef"
 
     DBusProxy {
         id: dbusproxy
@@ -30,6 +32,8 @@ ApplicationWindow
     RiskStatus {
         id: riskStatus
     }
+
+    Component.onCompleted: updating = (dbusproxy.exposureState(token) === DBusProxy.Working)
 
     function moreThanADayAgo(latest) {
         var result = true

--- a/qml/pages/Main.qml
+++ b/qml/pages/Main.qml
@@ -42,34 +42,6 @@ Page {
         }
     }
 
-    Connections {
-        target: dbusproxy
-
-        onExposureStateChanged: {
-            console.log("onExposureStateChanged token: " + token)
-            if (token === root.token) {
-                console.log("exposureState: " + dbusproxy.exposureState(token))
-                updating = (dbusproxy.exposureState(token) === DBusProxy.Working)
-                console.log("Updating: " + updating)
-            }
-        }
-
-        onActionExposureStateUpdated: {
-            console.log("onActionExposureStateUpdated token: " + token)
-            if (token === root.token) {
-                console.log("Exposure summary")
-                var summary = dbusproxy.getExposureSummary(token)
-                console.log("Attenuation durations: " + summary.attenuationDurations)
-                console.log("Days since last exposure: " + summary.daysSinceLastExposure)
-                console.log("Matched key count: " + summary.matchedKeyCount)
-                console.log("Maximum risk score: " + summary.maximumRiskScore)
-                console.log("Summation risk score: " + summary.summationRiskScore)
-                AppSettings.summaryUpdated = new Date()
-                AppSettings.latestSummary = summary
-            }
-        }
-    }
-
     SilicaListView {
         anchors.fill: parent
         VerticalScrollDecorator {}

--- a/qml/pages/Main.qml
+++ b/qml/pages/Main.qml
@@ -14,6 +14,7 @@ Page {
         var filelist = download.fileList()
         console.log("Files to check: " + filelist.length)
         updating = true
+
         dbusproxy.provideDiagnosisKeys(filelist, download.config, token)
     }
 
@@ -46,22 +47,20 @@ Page {
     Connections {
         target: dbusproxy
 
-        onProvideDiagnosisKeysResult: {
+        onActionExposureStateUpdated: {
             var summary
             if (token == page.token) {
                 updating = false;
 
-                if (status == DBusProxy.Success) {
-                    console.log("Exposure summary")
-                    summary = dbusproxy.getExposureSummary(token);
-                    console.log("Attenuation durations: " + summary.attenuationDurations)
-                    console.log("Days since last exposure: " + summary.daysSinceLastExposure)
-                    console.log("Matched key count: " + summary.matchedKeyCount)
-                    console.log("Maximum risk score: " + summary.maximumRiskScore)
-                    console.log("Summation risk score: " + summary.summationRiskScore)
-                    AppSettings.summaryUpdated = new Date()
-                    AppSettings.latestSummary = summary
-                }
+                console.log("Exposure summary")
+                summary = dbusproxy.getExposureSummary(token);
+                console.log("Attenuation durations: " + summary.attenuationDurations)
+                console.log("Days since last exposure: " + summary.daysSinceLastExposure)
+                console.log("Matched key count: " + summary.matchedKeyCount)
+                console.log("Maximum risk score: " + summary.maximumRiskScore)
+                console.log("Summation risk score: " + summary.summationRiskScore)
+                AppSettings.summaryUpdated = new Date()
+                AppSettings.latestSummary = summary
             }
         }
     }

--- a/qml/pages/Main.qml
+++ b/qml/pages/Main.qml
@@ -4,7 +4,6 @@ import uk.co.flypig.contrac 1.0
 
 Page {
     id: page
-    property string token: "abcdef"
     property bool updatePending
 
     allowedOrientations: Orientation.All
@@ -13,7 +12,6 @@ Page {
         updatePending = false
         var filelist = download.fileList()
         console.log("Files to check: " + filelist.length)
-        updating = true
 
         dbusproxy.provideDiagnosisKeys(filelist, download.config, token)
     }
@@ -47,13 +45,20 @@ Page {
     Connections {
         target: dbusproxy
 
-        onActionExposureStateUpdated: {
-            var summary
-            if (token == page.token) {
-                updating = false;
+        onExposureStateChanged: {
+            console.log("onExposureStateChanged token: " + token)
+            if (token === root.token) {
+                console.log("exposureState: " + dbusproxy.exposureState(token))
+                updating = (dbusproxy.exposureState(token) === DBusProxy.Working)
+                console.log("Updating: " + updating)
+            }
+        }
 
+        onActionExposureStateUpdated: {
+            console.log("onActionExposureStateUpdated token: " + token)
+            if (token === root.token) {
                 console.log("Exposure summary")
-                summary = dbusproxy.getExposureSummary(token);
+                var summary = dbusproxy.getExposureSummary(token)
                 console.log("Attenuation durations: " + summary.attenuationDurations)
                 console.log("Days since last exposure: " + summary.daysSinceLastExposure)
                 console.log("Matched key count: " + summary.matchedKeyCount)

--- a/src/dbusproxy.cpp
+++ b/src/dbusproxy.cpp
@@ -234,8 +234,15 @@ void DBusProxy::setRssiCorrection(qint32 rssiCorrection)
     }
 }
 
-DBusProxy::ExposureState DBusProxy::exposureState(QString const &token)
+DBusProxy::ExposureState DBusProxy::exposureState(QString const &token) const
 {
     QDBusReply<qint32> reply = m_interface->call("exposureState", token);
     return DBusProxy::ExposureState(reply.value());
 }
+
+QDateTime DBusProxy::lastProcessTime(QString const token) const
+{
+    QDBusReply<QDateTime> reply = m_interface->call("lastProcessTime", token);
+    return reply;
+}
+

--- a/src/dbusproxy.cpp
+++ b/src/dbusproxy.cpp
@@ -58,6 +58,9 @@ DBusProxy::DBusProxy(QObject *parent)
     signature = QStringLiteral("s");
     result = QDBusConnection::sessionBus().connect("uk.co.flypig.contrac", "/", "uk.co.flypig.contrac", "actionExposureStateUpdated", this, SIGNAL(actionExposureStateUpdated(QString)));
     qDebug() << "Connection actionExposureStateUpdated result: " << result;
+
+    result = QDBusConnection::sessionBus().connect("uk.co.flypig.contrac", "/", "uk.co.flypig.contrac", "exposureStateChanged", this, SIGNAL(exposureStateChanged(QString)));
+    qDebug() << "Connection exposureStateChanged result: " << result;
 }
 
 DBusProxy::~DBusProxy()
@@ -130,8 +133,8 @@ quint32 DBusProxy::sentCount() const
 
 DBusProxy::Status DBusProxy::status() const
 {
-    QDBusReply<DBusProxy::Status> reply = m_interface->call("status");
-    return reply;
+    QDBusReply<qint32> reply = m_interface->call("status");
+    return DBusProxy::Status(reply.value());
 }
 
 bool DBusProxy::isEnabled() const
@@ -229,4 +232,10 @@ void DBusProxy::setRssiCorrection(qint32 rssiCorrection)
     if (reply.type() == QDBusMessage::ErrorMessage) {
         qDebug() << "DBus error setting rssiCorrection: " << reply.errorMessage();
     }
+}
+
+DBusProxy::ExposureState DBusProxy::exposureState(QString const &token)
+{
+    QDBusReply<qint32> reply = m_interface->call("exposureState", token);
+    return DBusProxy::ExposureState(reply.value());
 }

--- a/src/dbusproxy.h
+++ b/src/dbusproxy.h
@@ -51,7 +51,7 @@ public:
     Q_INVOKABLE void start();
     Q_INVOKABLE void stop();
     Q_INVOKABLE QList<TemporaryExposureKey> getTemporaryExposureKeyHistory();
-    Q_INVOKABLE void provideDiagnosisKeys(QStringList const &keyFiles, ExposureConfiguration const &configuration, QString token);
+    Q_INVOKABLE void provideDiagnosisKeys(QStringList const &keyFiles, ExposureConfiguration *configuration, QString token);
     Q_INVOKABLE ExposureSummary *getExposureSummary(QString const &token) const;
     Q_INVOKABLE QList<ExposureInformation> *getExposureInformation(QString const &token) const;
     Q_INVOKABLE void resetAllData();
@@ -77,7 +77,7 @@ signals:
     void rssiCorrectionChanged();
 
     // Async responses
-    void provideDiagnosisKeysResult(Status status, QString const &token);
+    void actionExposureStateUpdated(QString token);
 
 public slots:
 

--- a/src/dbusproxy.h
+++ b/src/dbusproxy.h
@@ -16,7 +16,6 @@ class QDBusInterface;
 class DBusProxy : public QObject
 {
     Q_OBJECT
-    Q_ENUMS(Status)
 
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
     Q_PROPERTY(bool isEnabled READ isEnabled NOTIFY isEnabledChanged)
@@ -43,6 +42,14 @@ public:
         FailedInsufficientStorage,
         FailedInternal
     };
+    Q_ENUM(Status)
+
+    enum ExposureState
+    {
+        Idle = 0,
+        Working
+    };
+    Q_ENUM(ExposureState)
 
     Status status() const;
     bool isEnabled() const;
@@ -57,6 +64,7 @@ public:
     Q_INVOKABLE void resetAllData();
 
     // Non-standard additions
+    Q_INVOKABLE ExposureState exposureState(QString const &token);
     quint32 receivedCount() const;
     quint32 sentCount() const;
     bool isBusy() const;
@@ -75,6 +83,7 @@ signals:
     void isBusyChanged();
     void txPowerChanged();
     void rssiCorrectionChanged();
+    void exposureStateChanged(QString const &token);
 
     // Async responses
     void actionExposureStateUpdated(QString token);

--- a/src/dbusproxy.h
+++ b/src/dbusproxy.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QDBusPendingCall>
+#include <QDateTime>
 
 #include "../contracd/src/exposuresummary.h"
 #include "../contracd/src/exposureinformation.h"
@@ -46,8 +47,9 @@ public:
 
     enum ExposureState
     {
-        Idle = 0,
-        Working
+        None = 0,
+        Processing,
+        Available
     };
     Q_ENUM(ExposureState)
 
@@ -64,7 +66,7 @@ public:
     Q_INVOKABLE void resetAllData();
 
     // Non-standard additions
-    Q_INVOKABLE ExposureState exposureState(QString const &token);
+    Q_INVOKABLE ExposureState exposureState(QString const &token) const;
     quint32 receivedCount() const;
     quint32 sentCount() const;
     bool isBusy() const;
@@ -72,6 +74,7 @@ public:
     qint32 rssiCorrection() const;
     void setTxPower(qint32 txPower);
     void setRssiCorrection(qint32 rssiCorrection);
+    Q_INVOKABLE QDateTime lastProcessTime(QString const token) const;
 
 signals:
     void statusChanged();

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -390,8 +390,15 @@ void Download::setStatusError(ErrorType error)
     }
 }
 
-ExposureConfiguration const *Download::config() const
+ExposureConfiguration *Download::config() const
 {
+    qDebug() << "Minimum risk score set to: " << m_downloadConfig->config()->minimumRiskScore();
+    qDebug() << "Attenuation scores set to: " << m_downloadConfig->config()->attenuationScores();
+    qDebug() << "Days Since Last Exposure scores set to: " << m_downloadConfig->config()->daysSinceLastExposureScores();
+    qDebug() << "Duration scores set to: " << m_downloadConfig->config()->durationScores();
+    qDebug() << "Transmission Risk scores set to: " << m_downloadConfig->config()->transmissionRiskScores();
+    qDebug() << "Duration At Attenuation Thresholds set to: " << m_downloadConfig->config()->durationAtAttenuationThresholds();
+
     return m_downloadConfig->config();
 }
 

--- a/src/download.h
+++ b/src/download.h
@@ -20,7 +20,7 @@ class Download : public QObject
     Q_PROPERTY(float progress READ progress NOTIFY progressChanged)
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
     Q_PROPERTY(ErrorType error READ error NOTIFY errorChanged)
-    Q_PROPERTY(ExposureConfiguration config READ config NOTIFY configChanged)
+    Q_PROPERTY(ExposureConfiguration *config READ config NOTIFY configChanged)
 
 public:
     enum Status
@@ -46,7 +46,7 @@ public:
     Status status() const;
     ErrorType error() const;
     Q_INVOKABLE void clearError();
-    ExposureConfiguration const *config() const;
+    ExposureConfiguration *config() const;
 
 signals:
     void latestChanged();

--- a/src/downloadconfig.cpp
+++ b/src/downloadconfig.cpp
@@ -304,7 +304,7 @@ void DownloadConfig::applyConfiguration(diagnosis::ApplicationConfiguration cons
 
 }
 
-ExposureConfiguration const *DownloadConfig::config() const
+ExposureConfiguration *DownloadConfig::config() const
 {
     return m_configuration;
 }

--- a/src/downloadconfig.h
+++ b/src/downloadconfig.h
@@ -39,7 +39,7 @@ public:
     bool downloading() const;
     Status status() const;
     ErrorType error() const;
-    ExposureConfiguration const *config() const;
+    ExposureConfiguration *config() const;
 
 signals:
     void downloadingChanged();

--- a/tests/test_tracing.cpp
+++ b/tests/test_tracing.cpp
@@ -11,6 +11,7 @@
 #include "../contracd/proto/contrac.pb.h"
 #include "../src/appsettings.h"
 #include "../src/riskstatus.h"
+#include "../contracd/src/providediagnostickeys.h"
 
 #include "test_tracing.h"
 
@@ -468,7 +469,10 @@ void Test_Tracing::testMatchAggregation()
             }
         }
 
-        exposureInfoList = ExposureNotificationPrivate::aggregateExposureData(diagnosis.second, configuration, matches, 0);
+        QString token;
+        ProvideDiagnosticKeys provideDiagnosticKeys(nullptr, QVector<QString>(), ExposureConfiguration(), token, 5);
+
+        exposureInfoList = provideDiagnosticKeys.aggregateExposureData(diagnosis.second, configuration, matches, 0);
         for (ExposureInformation exposureInfo : exposureInfoList) {
             bool match = false;
             int checkPos;
@@ -614,16 +618,16 @@ void Test_Tracing::testStorage()
 
     // Files will be harvested down to the last DAYS_TO_STORE (which should be at least 14)
     QVERIFY(DAYS_TO_STORE >= 14u);
-    QCOMPARE(countDataFiles(), DAYS_TO_STORE);
-    QCOMPARE(countBloomFiles(), DAYS_TO_STORE);
+    QCOMPARE(countDataFiles(), quint32(DAYS_TO_STORE));
+    QCOMPARE(countBloomFiles(), quint32(DAYS_TO_STORE));
 
     storage = new ContactStorage(contrac);
     QVERIFY(storage != nullptr);
 
     storage->harvestOldData();
 
-    QCOMPARE(countDataFiles(), DAYS_TO_STORE);
-    QCOMPARE(countBloomFiles(), DAYS_TO_STORE);
+    QCOMPARE(countDataFiles(), quint32(DAYS_TO_STORE));
+    QCOMPARE(countBloomFiles(), quint32(DAYS_TO_STORE));
 
     // Clean up
     delete storage;

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -63,11 +63,12 @@ HEADERS += \
     ../contracd/src/exposuresummary.h \
     ../contracd/src/fnv.h \
     ../contracd/src/hkdfsha256.h \
+    ../contracd/src/metadata.h \
+    ../contracd/src/providediagnostickeys.h \
     ../contracd/src/rpidataitem.h \
     ../contracd/src/settings.h \
     ../contracd/src/temporaryexposurekey.h \
-    ../contracd/src/zipistreambuffer.h \
-    ../contracd/src/metadata.h
+    ../contracd/src/zipistreambuffer.h
 
 SOURCES += \
     ../src/contactmodel.cpp \
@@ -92,11 +93,12 @@ SOURCES += \
     ../contracd/src/exposuresummary.cpp \
     ../contracd/src/fnv.cpp \
     ../contracd/src/hkdfsha256.cpp \
+    ../contracd/src/metadata.cpp \
+    ../contracd/src/providediagnostickeys.cpp \
     ../contracd/src/rpidataitem.cpp \
     ../contracd/src/settings.cpp \
     ../contracd/src/temporaryexposurekey.cpp \
-    ../contracd/src/zipistreambuffer.cpp \
-    ../contracd/src/metadata.cpp
+    ../contracd/src/zipistreambuffer.cpp
 
 INCLUDEPATH += $$OUT_PWD/../contracd/proto $$OUT_PWD/../proto
 


### PR DESCRIPTION
The risk calculation triggered when `ProvideDiagnosticKeys` is called can
take a long time, so it's better to run it on a separate thread in order
to allow other tasks (such as the beacon send/receive) to continue
running while the calculation takes place.

This moves the calculation into its own thread. It also changes the API
slightly so that the `provideDiagnosisKeys()` dbus call no longer blocks,
but instead notifies completion using the `actionExposureStateUpdated()`
signal.

This also better matches the GAEN API.