### PR TITLE
Support automatic update of diagnosis keys

### DIFF
--- a/contrac.pro
+++ b/contrac.pro
@@ -40,6 +40,7 @@ HEADERS += \
     proto/submissionpayload.pb.h \
     proto/applicationConfiguration.pb.h \
     src/appsettings.h \
+    src/autoupdate.h \
     src/dbusproxy.h \
     src/contactmodel.h \
     src/download.h \
@@ -60,6 +61,7 @@ SOURCES += \
     proto/submissionpayload.pb.cc \
     proto/applicationConfiguration.pb.cc \
     src/appsettings.cpp \
+    src/autoupdate.cpp \
     src/downloadconfig.cpp \
     src/harbour-contrac.cpp \
     src/dbusproxy.cpp \
@@ -114,6 +116,7 @@ PKGCONFIG += \
     openssl \
     libxml-2.0 \
     libcurl \
+    keepalive \
     protobuf-lite \
     quazip
 

--- a/contracd/src/dbusinterface.h
+++ b/contracd/src/dbusinterface.h
@@ -77,6 +77,4 @@ private:
     ExposureNotification m_exposureNotification;
 };
 
-
-
 #endif // DBUSINTERFACE_H

--- a/qml/harbour-contrac.qml
+++ b/qml/harbour-contrac.qml
@@ -2,6 +2,7 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 import org.nemomobile.time 1.0
 import uk.co.flypig.contrac 1.0
+import Nemo.DBus 2.0
 import "pages"
 
 ApplicationWindow
@@ -22,6 +23,11 @@ ApplicationWindow
 
     Download {
         id: download
+        onDownloadingChanged: {
+            if (!downloading) {
+                autoUpdate.updateComplete();
+            }
+        }
     }
 
     WallClock {
@@ -31,6 +37,13 @@ ApplicationWindow
 
     RiskStatus {
         id: riskStatus
+    }
+
+    AutoUpdate {
+        id: autoUpdate
+        onStartUpdate: {
+            download.downloadLatest()
+        }
     }
 
     function updateSummary() {

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -24,11 +24,48 @@ Page {
         Column {
             id: settingsColumn
             width: parent.width
-            spacing: Theme.paddingLarge
 
             PageHeader {
                 //% "Settings"
                 title: qsTrId("contrac-settings_he_settings")
+            }
+
+            SectionHeader {
+                //% "Daily update"
+                text: qsTrId("contrac-settings_he_daily-update")
+            }
+
+            TextSwitch {
+                //% "Perform daily update"
+                text: qsTrId("contrac-settings_ts_perform-daily-update")
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                checked: AppSettings.autoUpdate
+                automaticCheck: false
+                onClicked: AppSettings.autoUpdate = !checked
+            }
+
+            ValueButton {
+                //% "Approximate update time"
+                label: qsTrId("contrac-settings_vb_approx_update-time")
+                //% "The app must be running for the update to trigger"
+                description: qsTrId("contrac-settings_vb_approx_update-time-description")
+                enabled: AppSettings.autoUpdate
+                value: {
+                    var time = new Date()
+                    time.setHours(AppSettings.autoUpdateTime / (60 * 60))
+                    time.setMinutes((AppSettings.autoUpdateTime / 60) % 60)
+                    Format.formatDate(time, Formatter.TimeValue)
+                }
+                onClicked: {
+                    var hours = AppSettings.autoUpdateTime / (60 * 60)
+                    var minutes = (AppSettings.autoUpdateTime / 60) % 60
+                    var obj = pageStack.animatorPush("Sailfish.Silica.TimePickerDialog", {hour: hours, minute: minutes})
+                    obj.pageCompleted.connect(function(page) {
+                        page.accepted.connect(function() {
+                            AppSettings.autoUpdateTime = ((page.hour * 60) + page.minute) * 60
+                        })
+                    })
+                }
             }
 
             SectionHeader {
@@ -79,7 +116,7 @@ Page {
                 Component.onCompleted: {
                     var codes = ["DE", "EUR"]
                     currentIndex = codes.indexOf(AppSettings.countryCode)
-                    console.log("Changing country code to:" + currentIndex)
+                    console.log("Changing country code to: " + currentIndex)
                 }
                 menu: ContextMenu {
                     MenuItem {

--- a/rpm/harbour-contrac.spec
+++ b/rpm/harbour-contrac.spec
@@ -25,6 +25,7 @@ BuildRequires:  pkgconfig(protobuf-lite)
 BuildRequires:  pkgconfig(libcurl)
 BuildRequires:  pkgconfig(libxml-2.0)
 BuildRequires:  pkgconfig(quazip)
+BuildRequires:  pkgconfig(keepalive)
 BuildRequires:  protobuf-compiler
 BuildRequires:  desktop-file-utils
 

--- a/rpm/harbour-contrac.yaml
+++ b/rpm/harbour-contrac.yaml
@@ -29,6 +29,7 @@ PkgConfigBR:
   - libcurl
   - libxml-2.0
   - quazip
+  - keepalive
 
 # Build dependencies without a pkgconfig setup can be listed here
 PkgBR:
@@ -36,10 +37,9 @@ PkgBR:
 
 # Runtime dependencies which are not automatically detected
 Requires:
-  - sailfishsilica-qt5 >= 0.10.9 
+  - sailfishsilica-qt5 >= 0.10.9
   - openssl
   - protobuf-lite
-  - nemo-qml-plugin-time-qt5
 
 # All installed files
 Files:

--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -8,6 +8,7 @@
 #include "appsettings.h"
 
 #define SETTINGS_MAX_VERSION (1)
+#define DEFAULT_AUTO_UPDATE_TIME (60 * 60 * 4)
 
 AppSettings *AppSettings::instance = nullptr;
 
@@ -22,6 +23,8 @@ AppSettings::AppSettings(QObject *parent)
     m_summaryUpdated = m_settings.value(QStringLiteral("update/date"), QDateTime()).toDateTime();
     m_infoViewed = m_settings.value(QStringLiteral("application/infoViewed"), 0).toUInt();
     m_countryCode = m_settings.value(QStringLiteral("update/countryCode"), QStringLiteral("DE")).toString();
+    m_autoUpdate = m_settings.value(QStringLiteral("update/autoUpdate"), false).toBool();
+    m_autoUpdateTime = m_settings.value(QStringLiteral("update/autoUpdateTime"), DEFAULT_AUTO_UPDATE_TIME).toInt() % (60 * 60 * 24);
 
     // Set
     m_riskWeights.append(m_settings.value(QStringLiteral("combinedRisk/riskWeightLow"), 1.0).toDouble());
@@ -72,6 +75,8 @@ AppSettings::~AppSettings()
     m_settings.setValue(QStringLiteral("update/date"), m_summaryUpdated);
     m_settings.setValue(QStringLiteral("application/infoViewed"), m_infoViewed);
     m_settings.setValue(QStringLiteral("update/countryCode"), m_countryCode);
+    m_settings.setValue(QStringLiteral("update/autoUpdate"), m_autoUpdate);
+    m_settings.setValue(QStringLiteral("update/autoUpdateTime"), m_autoUpdateTime);
 
     // Store
     while (m_riskWeights.size() < 3) {
@@ -202,6 +207,33 @@ void AppSettings::setCountryCode(QString countryCode)
     if (m_countryCode != countryCode) {
         m_countryCode = countryCode;
         emit countryCodeChanged();
+    }
+}
+
+bool AppSettings::autoUpdate() const
+{
+    return m_autoUpdate;
+}
+
+void AppSettings::setAutoUpdate(bool autoUpdate)
+{
+    if (m_autoUpdate != autoUpdate) {
+        m_autoUpdate = autoUpdate;
+        emit autoUpdateChanged();
+    }
+}
+
+qint32 AppSettings::autoUpdateTime() const
+{
+    return m_autoUpdateTime % (60 * 60 * 24);
+}
+
+void AppSettings::setAutoUpdateTime(qint32 autoUpdateTime)
+{
+    autoUpdateTime = autoUpdateTime % (60 * 60 * 24);
+    if (m_autoUpdateTime != autoUpdateTime) {
+        m_autoUpdateTime = autoUpdateTime;
+        emit autoUpdateTimeChanged();
     }
 }
 

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -23,6 +23,8 @@ class AppSettings : public QObject
     Q_PROPERTY(QDateTime summaryUpdated READ summaryUpdated WRITE setSummaryUpdated NOTIFY summaryUpdatedChanged)
     Q_PROPERTY(quint32 infoViewed READ infoViewed WRITE setInfoViewed NOTIFY infoViewedChanged)
     Q_PROPERTY(QString countryCode READ countryCode WRITE setCountryCode NOTIFY countryCodeChanged)
+    Q_PROPERTY(bool autoUpdate READ autoUpdate WRITE setAutoUpdate NOTIFY autoUpdateChanged)
+    Q_PROPERTY(qint32 autoUpdateTime READ autoUpdateTime WRITE setAutoUpdateTime NOTIFY autoUpdateTimeChanged)
 
     // Attenuation duration properties
     Q_PROPERTY(QList<double> riskWeights READ riskWeights WRITE setRiskWeights NOTIFY riskWeightsChanged)
@@ -38,21 +40,43 @@ public:
     static AppSettings &getInstance();
     static QObject *provider(QQmlEngine *engine, QJSEngine *scriptEngine);
 
-    Q_INVOKABLE QString downloadServer() const;
-    Q_INVOKABLE QString uploadServer() const;
-    Q_INVOKABLE QString verificationServer() const;
-    Q_INVOKABLE ExposureSummary *latestSummary();
-    Q_INVOKABLE QDateTime summaryUpdated() const;
-    Q_INVOKABLE quint32 infoViewed() const;
-    Q_INVOKABLE QString countryCode() const;
-
-    Q_INVOKABLE QList<double> riskWeights() const;
-    Q_INVOKABLE qint32 defaultBuckeOffset() const;
-    Q_INVOKABLE qint32 normalizationDivisor() const;
-    Q_INVOKABLE QList<RiskScoreClass> riskScoreClasses() const;
-
+    // Constant image properties
     Q_INVOKABLE QString getImageDir() const;
     Q_INVOKABLE QString getImageUrl(QString const &id) const;
+
+    // Get general properties
+    QString downloadServer() const;
+    QString uploadServer() const;
+    QString verificationServer() const;
+    ExposureSummary *latestSummary();
+    QDateTime summaryUpdated() const;
+    quint32 infoViewed() const;
+    QString countryCode() const;
+    bool autoUpdate() const;
+    qint32 autoUpdateTime() const;
+
+    // Get attenuation duration properties
+    QList<double> riskWeights() const;
+    qint32 defaultBuckeOffset() const;
+    qint32 normalizationDivisor() const;
+    QList<RiskScoreClass> riskScoreClasses() const;
+
+    // Set general properties
+    void setDownloadServer(QString const &downloadServer);
+    void setUploadServer(QString const &uploadServer);
+    void setVerificationServer(QString const &verificationServer);
+    void setLatestSummary(ExposureSummary const *latestSummary);
+    void setSummaryUpdated(QDateTime summaryUpdated);
+    void setInfoViewed(quint32 infoViewed);
+    void setCountryCode(QString countryCode);
+    void setAutoUpdate(bool autoUpdate);
+    void setAutoUpdateTime(qint32 autoUpdateTime);
+
+    // Set attenuation duration properties
+    void setRiskWeights(QList<double> riskWeights);
+    void setDefaultBuckeOffset(qint32 defaultBuckeOffset);
+    void setNormalizationDivisor(qint32 normalizationDivisor);
+    void setRiskScoreClasses(QList<RiskScoreClass> riskScoreClasses);
 
 signals:
     void downloadServerChanged();
@@ -66,19 +90,8 @@ signals:
     void defaultBuckeOffsetChanged();
     void normalizationDivisorChanged();
     void riskScoreClassesChanged();
-
-public slots:
-    void setDownloadServer(QString const &downloadServer);
-    void setUploadServer(QString const &uploadServer);
-    void setVerificationServer(QString const &verificationServer);
-    void setLatestSummary(ExposureSummary const *latestSummary);
-    void setSummaryUpdated(QDateTime summaryUpdated);
-    void setInfoViewed(quint32 infoViewed);
-    void setCountryCode(QString countryCode);
-    void setRiskWeights(QList<double> riskWeights);
-    void setDefaultBuckeOffset(qint32 defaultBuckeOffset);
-    void setNormalizationDivisor(qint32 normalizationDivisor);
-    void setRiskScoreClasses(QList<RiskScoreClass> riskScoreClasses);
+    void autoUpdateChanged();
+    void autoUpdateTimeChanged();
 
 private:
     bool upgrade();
@@ -88,6 +101,7 @@ private:
     static AppSettings *instance;
     QSettings m_settings;
 
+    QString m_imageDir;
     QString m_downloadServer;
     QString m_uploadServer;
     QString m_verificationServer;
@@ -95,11 +109,12 @@ private:
     QDateTime m_summaryUpdated;
     quint32 m_infoViewed;
     QString m_countryCode;
-    QString m_imageDir;
     QList<double> m_riskWeights;
     qint32 m_defaultBuckeOffset;
     qint32 m_normalizationDivisor;
     QList<RiskScoreClass> m_riskScoreClasses;
+    bool m_autoUpdate;
+    qint32 m_autoUpdateTime;
 };
 
 #endif // APPSETTINGS_H

--- a/src/autoupdate.cpp
+++ b/src/autoupdate.cpp
@@ -1,0 +1,143 @@
+#include <QDateTime>
+#include <QDebug>
+
+#include <backgroundactivity.h>
+
+#include "appsettings.h"
+#include "autoupdate.h"
+
+AutoUpdate::AutoUpdate(QObject *parent)
+    : QObject(parent)
+    , m_backgroundActivity(new BackgroundActivity(this))
+    , m_running(false)
+    , m_settings(AppSettings::getInstance())
+{
+    connect(m_backgroundActivity, &BackgroundActivity::stateChanged, this, &AutoUpdate::stateChanged);
+
+    connect(&m_settings, &AppSettings::autoUpdateChanged, this, &AutoUpdate::autoUpdateSettingChanged);
+    connect(&m_settings, &AppSettings::autoUpdateTimeChanged, this, &AutoUpdate::autoUpdateTimeSettingChanged);
+
+    configureNextUpdate();
+}
+
+AutoUpdate::~AutoUpdate()
+{
+    qDebug() << "Stopping all auto update triggers";
+    m_running = false;
+    m_backgroundActivity->stop();
+
+    emit runningChanged();
+}
+
+bool AutoUpdate::running() const
+{
+    return m_running;
+}
+
+void AutoUpdate::setRunning(bool running)
+{
+    if (m_running != running) {
+        m_running = running;
+        emit runningChanged();
+    }
+}
+
+bool AutoUpdate::autoUpdate() const
+{
+    return m_settings.autoUpdate();
+}
+
+void AutoUpdate::setAutoUpdate(bool autoUpdate)
+{
+    m_settings.setAutoUpdate(autoUpdate);
+
+    if (!m_running) {
+        if (autoUpdate) {
+            qDebug() << "Enabling auto update for:" << m_settings.autoUpdateTime();
+            m_backgroundActivity->wait();
+        }
+        else {
+            qDebug() << "Disabling auto update";
+            m_backgroundActivity->stop();
+        }
+    }
+}
+
+qint32 AutoUpdate::updateTime() const
+{
+    return m_settings.autoUpdateTime();
+}
+
+void AutoUpdate::setUpdateTime(qint32 time)
+{
+    m_settings.setAutoUpdateTime(time);
+}
+
+void AutoUpdate::stateChanged()
+{
+    if (m_backgroundActivity->isRunning()) {
+        m_running = true;
+        emit runningChanged();
+        qDebug() << "Auto update started";
+        emit startUpdate();
+    }
+}
+
+void AutoUpdate::updateComplete()
+{
+    if (m_running) {
+        qDebug() << "Auto update complete";
+        m_running = false;
+
+        if (autoUpdate()) {
+            configureNextUpdate();
+        }
+        else {
+            m_backgroundActivity->stop();
+        }
+
+        emit runningChanged();
+    }
+}
+
+void AutoUpdate::configureNextUpdate()
+{
+    qint32 const autoUpdateTime = m_settings.autoUpdateTime();
+    qDebug() << "Configuring auto update time to:" << autoUpdateTime;
+
+    qDebug() << "Current time:" << (QTime::currentTime().msecsSinceStartOfDay() / 1000);
+
+    int delay = (60 * 60 * 24) + m_settings.autoUpdateTime();
+    delay -= (QTime::currentTime().msecsSinceStartOfDay() / 1000);
+    delay = delay % (60 * 60 * 24);
+    if (delay < 60) {
+        delay += 60 * 60 * 24;
+    }
+
+    // To the nearest quarter of an hour
+    m_backgroundActivity->setWakeupRange(delay, delay + (60 * 5));
+
+    if (autoUpdate()) {
+        qDebug() << "AutoUpdate active, will trigger in" << delay << "seconds";
+        if (!m_running) {
+            m_backgroundActivity->wait();
+        }
+    }
+    else {
+        qDebug() << "AutoUpdate inactive, would trigger in" << delay << "seconds";
+    }
+}
+
+void AutoUpdate::autoUpdateSettingChanged()
+{
+    configureNextUpdate();
+
+    emit autoUpdateChanged();
+}
+
+void AutoUpdate::autoUpdateTimeSettingChanged()
+{
+    configureNextUpdate();
+
+    emit updateTimeChanged();
+}

--- a/src/autoupdate.h
+++ b/src/autoupdate.h
@@ -1,0 +1,53 @@
+#ifndef AUTOUPDATE_H
+#define AUTOUPDATE_H
+
+#include <QObject>
+#include <QTime>
+#include <QtDBus>
+
+class BackgroundActivity;
+class AppSettings;
+
+class AutoUpdate : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool running READ running WRITE setRunning NOTIFY runningChanged)
+    Q_PROPERTY(bool autoUpdate READ autoUpdate WRITE setAutoUpdate NOTIFY autoUpdateChanged)
+    Q_PROPERTY(qint32 updateTime READ updateTime WRITE setUpdateTime NOTIFY updateTimeChanged)
+
+public:
+    explicit AutoUpdate(QObject *parent = nullptr);
+    ~AutoUpdate();
+
+    bool running() const;
+    bool autoUpdate() const;
+    qint32 updateTime() const;
+    void setRunning(bool running);
+    void setAutoUpdate(bool autoUpdate);
+    void setUpdateTime(qint32 updateTime);
+
+public slots:
+    void updateComplete();
+
+signals:
+    void startUpdate();
+    void runningChanged();
+    void autoUpdateChanged();
+    void updateTimeChanged();
+
+private slots:
+    void stateChanged();
+    void autoUpdateSettingChanged();
+    void autoUpdateTimeSettingChanged();
+
+private:
+    void configureNextUpdate();
+
+private:
+    BackgroundActivity *m_backgroundActivity;
+    bool m_running;
+    AppSettings &m_settings;
+};
+
+#endif // AUTOUPDATE_H

--- a/src/dbusproxy.cpp
+++ b/src/dbusproxy.cpp
@@ -7,6 +7,8 @@
 
 #include "dbusproxy.h"
 
+#define SERVICE_NAME "uk.co.flypig.contrac"
+
 // D-bus timeout in milliseconds
 // Some of the calls such as provideDiagnosisKeys() are potentially very long running
 #define DBUS_PROXY_TIMEOUT (10 * 60 * 1000)

--- a/src/dbusproxy.h
+++ b/src/dbusproxy.h
@@ -12,8 +12,6 @@
 
 class QDBusInterface;
 
-#define SERVICE_NAME "uk.co.flypig.contrac"
-
 class DBusProxy : public QObject
 {
     Q_OBJECT

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -50,7 +50,7 @@ QDate latestDownloaded()
         }
     }
 
-    qDebug() << "Latest download directory date: " << latest;
+    qDebug() << "Latest download directory date: " << latest.toString();
     return latest;
 }
 

--- a/src/harbour-contrac.cpp
+++ b/src/harbour-contrac.cpp
@@ -10,6 +10,7 @@
 #include <QtQuick>
 
 #include "appsettings.h"
+#include "autoupdate.h"
 #include "dbusproxy.h"
 #include "download.h"
 #include "downloadconfig.h"
@@ -56,6 +57,7 @@ int main(int argc, char *argv[])
     qmlRegisterType<Upload>("uk.co.flypig.contrac", 1, 0, "Upload");
     qmlRegisterType<DownloadConfig>("uk.co.flypig.contrac", 1, 0, "DownloadConfig");
     qmlRegisterType<RiskStatus>("uk.co.flypig.contrac", 1, 0, "RiskStatus");
+    qmlRegisterType<AutoUpdate>("uk.co.flypig.contrac", 1, 0, "AutoUpdate");
 
     qmlRegisterSingletonType<AppSettings>("uk.co.flypig.contrac", 1, 0, "AppSettings", AppSettings::provider);
 

--- a/translations/harbour-contrac-de.ts
+++ b/translations/harbour-contrac-de.ts
@@ -311,5 +311,21 @@
         <source>Download coverage</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="contrac-settings_he_daily-update">
+        <source>Daily update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_ts_perform-daily-update">
+        <source>Perform daily update</source>
+        <translation type="unfinished">Tägliche Aktualisierung durchführen</translation>
+    </message>
+    <message id="contrac-settings_vb_approx_update-time">
+        <source>Approximate update time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_vb_approx_update-time-description">
+        <source>The app must be running for the update to trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/harbour-contrac-en.ts
+++ b/translations/harbour-contrac-en.ts
@@ -313,5 +313,21 @@
         <source>Download coverage</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="contrac-settings_he_daily-update">
+        <source>Daily update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_ts_perform-daily-update">
+        <source>Perform daily update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_vb_approx_update-time">
+        <source>Approximate update time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_vb_approx_update-time-description">
+        <source>The app must be running for the update to trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/harbour-contrac-zh_CN.ts
+++ b/translations/harbour-contrac-zh_CN.ts
@@ -313,5 +313,21 @@
         <source>Download coverage</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="contrac-settings_he_daily-update">
+        <source>Daily update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_ts_perform-daily-update">
+        <source>Perform daily update</source>
+        <translation type="unfinished">执行每日更新</translation>
+    </message>
+    <message id="contrac-settings_vb_approx_update-time">
+        <source>Approximate update time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_vb_approx_update-time-description">
+        <source>The app must be running for the update to trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/harbour-contrac.ts
+++ b/translations/harbour-contrac.ts
@@ -313,5 +313,21 @@
         <source>Download coverage</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="contrac-settings_he_daily-update">
+        <source>Daily update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_ts_perform-daily-update">
+        <source>Perform daily update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_vb_approx_update-time">
+        <source>Approximate update time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_vb_approx_update-time-description">
+        <source>The app must be running for the update to trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>


### PR DESCRIPTION
Currently the user has to manually update the diagnosis keys from the server each day.

This change adds the ability to set the app to perform an automatic update at a specified time each day.