### PR TITLE
Download by day; support different download regions

### DIFF
--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -32,8 +32,8 @@ Page {
             }
 
             SectionHeader {
-                //% "Servers"
-                text: qsTrId("contrac-settings_he_servers")
+                //% "Server details"
+                text: qsTrId("contrac-settings_he_server_details")
             }
 
             TextField {
@@ -71,6 +71,28 @@ Page {
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
                 EnterKey.onClicked: txPowerEntry.focus = true
             }
+
+            ComboBox {
+                id: countryCode
+                //% "Download coverage"
+                label: qsTrId("contrac-settings_co_download-coverage")
+                Component.onCompleted: {
+                    var codes = ["DE", "EUR"]
+                    currentIndex = codes.indexOf(AppSettings.countryCode)
+                    console.log("Changing country code to:" + currentIndex)
+                }
+                menu: ContextMenu {
+                    MenuItem {
+                        text: "Germany"
+                        onClicked: AppSettings.countryCode = "DE"
+                    }
+                    MenuItem {
+                        text: "Europe"
+                        onClicked: AppSettings.countryCode = "EUR"
+                    }
+                }
+            }
+
 
             SectionHeader {
                 //% "Attenuation calibration"

--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -19,6 +19,7 @@ AppSettings::AppSettings(QObject *parent) : QObject(parent),
     m_latestSummary = m_settings.value(QStringLiteral("update/latestSummary"), QVariant::fromValue<ExposureSummary>(ExposureSummary())).value<ExposureSummary>();
     m_summaryUpdated = m_settings.value(QStringLiteral("update/date"), QDateTime()).toDateTime();
     m_infoViewed = m_settings.value(QStringLiteral("application/infoViewed"), 0).toUInt();
+    m_countryCode = m_settings.value(QStringLiteral("update/countryCode"), QStringLiteral("DE")).toString();
 
     // Set
     m_riskWeights.append(m_settings.value(QStringLiteral("combinedRisk/riskWeightLow"), 1.0).toDouble());
@@ -68,6 +69,7 @@ AppSettings::~AppSettings()
     m_settings.setValue(QStringLiteral("update/latestSummary"), QVariant::fromValue<ExposureSummary>(m_latestSummary));
     m_settings.setValue(QStringLiteral("update/date"), m_summaryUpdated);
     m_settings.setValue(QStringLiteral("application/infoViewed"), m_infoViewed);
+    m_settings.setValue(QStringLiteral("update/countryCode"), m_countryCode);
 
     // Store
     while (m_riskWeights.size() < 3) {
@@ -182,6 +184,19 @@ void AppSettings::setInfoViewed(quint32 infoViewed)
     if (m_infoViewed != infoViewed) {
         m_infoViewed = infoViewed;
         emit infoViewedChanged();
+    }
+}
+
+QString AppSettings::countryCode() const
+{
+    return m_countryCode;
+}
+
+void AppSettings::setCountryCode(QString countryCode)
+{
+    if (m_countryCode != countryCode) {
+        m_countryCode = countryCode;
+        emit countryCodeChanged();
     }
 }
 

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -22,6 +22,7 @@ class AppSettings : public QObject
     Q_PROPERTY(ExposureSummary *latestSummary READ latestSummary WRITE setLatestSummary NOTIFY latestSummaryChanged)
     Q_PROPERTY(QDateTime summaryUpdated READ summaryUpdated WRITE setSummaryUpdated NOTIFY summaryUpdatedChanged)
     Q_PROPERTY(quint32 infoViewed READ infoViewed WRITE setInfoViewed NOTIFY infoViewedChanged)
+    Q_PROPERTY(QString countryCode READ countryCode WRITE setCountryCode NOTIFY countryCodeChanged)
 
     // Attenuation duration properties
     Q_PROPERTY(QList<double> riskWeights READ riskWeights WRITE setRiskWeights NOTIFY riskWeightsChanged)
@@ -43,6 +44,7 @@ public:
     Q_INVOKABLE ExposureSummary *latestSummary();
     Q_INVOKABLE QDateTime summaryUpdated() const;
     Q_INVOKABLE quint32 infoViewed() const;
+    Q_INVOKABLE QString countryCode() const;
 
     Q_INVOKABLE QList<double> riskWeights() const;
     Q_INVOKABLE qint32 defaultBuckeOffset() const;
@@ -59,6 +61,7 @@ signals:
     void latestSummaryChanged();
     void summaryUpdatedChanged();
     void infoViewedChanged();
+    void countryCodeChanged();
     void riskWeightsChanged();
     void defaultBuckeOffsetChanged();
     void normalizationDivisorChanged();
@@ -71,6 +74,7 @@ public slots:
     void setLatestSummary(ExposureSummary const *latestSummary);
     void setSummaryUpdated(QDateTime summaryUpdated);
     void setInfoViewed(quint32 infoViewed);
+    void setCountryCode(QString countryCode);
     void setRiskWeights(QList<double> riskWeights);
     void setDefaultBuckeOffset(qint32 defaultBuckeOffset);
     void setNormalizationDivisor(qint32 normalizationDivisor);
@@ -90,6 +94,7 @@ private:
     ExposureSummary m_latestSummary;
     QDateTime m_summaryUpdated;
     quint32 m_infoViewed;
+    QString m_countryCode;
     QString m_imageDir;
     QList<double> m_riskWeights;
     qint32 m_defaultBuckeOffset;

--- a/src/download.h
+++ b/src/download.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QDate>
 #include <QMap>
+#include <QSet>
 
 #include "../contracd/src/exposureconfiguration.h"
 
@@ -63,19 +64,17 @@ private slots:
     void configDownloadComplete(QString const &filename);
 
 private:
-    void addToFileQueue(QDate const &date, QStringList const& download);
+    void downloadDateList();
+    void addToFileQueue(QString const& download);
     void startNextFileDownload();
-    void startNextDateDownload();
-    void startDateDownload(QDate const &date);
-    QDate nextDownloadDay() const;
-    QDate oldestDateInQueue();
     void createDateFolder(QDate const &date) const;
     void finalise();
     void setStatusError(ErrorType error);
+    void cleanUpDownloads();
 
 private:
     ServerAccess *m_serverAccess;
-    QMap<QDate, QStringList> m_fileQueue;
+    QStringList m_fileQueue;
     QDate m_latest;
     bool m_downloading;
     qint64 m_filesReceived;
@@ -83,6 +82,8 @@ private:
     Status m_status;
     ErrorType m_error;
     DownloadConfig * m_downloadConfig;
+    QString m_countryCode;
+    QSet<QDate> m_downloadedPreviously;
 };
 
 #endif // DOWNLOAD_H

--- a/src/download.h
+++ b/src/download.h
@@ -62,6 +62,7 @@ signals:
 private slots:
     void setStatus(Status status);
     void configDownloadComplete(QString const &filename);
+    void fileProgress(qint64 bytesReceived, qint64 bytesTotal);
 
 private:
     void downloadDateList();
@@ -84,6 +85,7 @@ private:
     DownloadConfig * m_downloadConfig;
     QString m_countryCode;
     QSet<QDate> m_downloadedPreviously;
+    float m_fileProgress;
 };
 
 #endif // DOWNLOAD_H

--- a/src/serveraccess.cpp
+++ b/src/serveraccess.cpp
@@ -244,7 +244,7 @@ void ServerListResult::onFinished()
                 break;
             }
             if (!converted.isEmpty()) {
-                m_keys.append(m_prefix + "/" + converted);
+                m_keys.append(converted);
             }
         }
         emit keysChanged();

--- a/src/serveraccess.cpp
+++ b/src/serveraccess.cpp
@@ -54,6 +54,7 @@ ServerResult::ServerResult(QNetworkReply *reply, QObject *parent) : QObject(pare
   , m_reply(reply)
 {
     connect(reply, &QNetworkReply::finished, this, &ServerResult::onFinished);
+    connect(reply, &QNetworkReply::downloadProgress, this, &ServerResult::progress);
 }
 
 ServerListResult::ServerListResult(QNetworkReply *reply, QString const &prefix, QObject *parent)

--- a/src/serveraccess.h
+++ b/src/serveraccess.h
@@ -16,6 +16,7 @@ public:
 
 signals:
     void finished();
+    void progress(qint64 bytesReceived, qint64 bytesTotal);
 
 protected slots:
     virtual void onFinished();

--- a/translations/harbour-contrac-de.ts
+++ b/translations/harbour-contrac-de.ts
@@ -55,10 +55,6 @@
         <source>Received</source>
         <translation>Empfangen</translation>
     </message>
-    <message id="contrac-settings_he_servers">
-        <source>Servers</source>
-        <translation>Server</translation>
-    </message>
     <message id="contrac-settings_tf_download_server">
         <source>Download server</source>
         <translation>Download-Server</translation>
@@ -306,6 +302,14 @@
     <message id="contrac-info_view-again">
         <source>You can view this page again by visiting the About page.</source>
         <translation>Sie können diese Seite erneut aufrufen, indem Sie die “Über”-Seite besuchen.</translation>
+    </message>
+    <message id="contrac-settings_he_server_details">
+        <source>Server details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_co_download-coverage">
+        <source>Download coverage</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-contrac-en.ts
+++ b/translations/harbour-contrac-en.ts
@@ -55,10 +55,6 @@
         <source>Received</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-settings_he_servers">
-        <source>Servers</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-settings_tf_download_server">
         <source>Download server</source>
         <translation type="unfinished"></translation>
@@ -307,6 +303,14 @@
     <message id="contrac-info_view-again">
         <source>You can view this page again by visiting the About page.</source>
         <oldsource>You can view this page again by visiting the About page</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_he_server_details">
+        <source>Server details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_co_download-coverage">
+        <source>Download coverage</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-contrac-zh_CN.ts
+++ b/translations/harbour-contrac-zh_CN.ts
@@ -55,10 +55,6 @@
         <source>Received</source>
         <translation>接收</translation>
     </message>
-    <message id="contrac-settings_he_servers">
-        <source>Servers</source>
-        <translation>服务器</translation>
-    </message>
     <message id="contrac-settings_tf_download_server">
         <source>Download server</source>
         <translation>下载服务器</translation>
@@ -308,6 +304,14 @@
         <source>You can view this page again by visiting the About page.</source>
         <oldsource>You can view this page again by visiting the About page</oldsource>
         <translation>你可以通过关于页再次查看此页面。</translation>
+    </message>
+    <message id="contrac-settings_he_server_details">
+        <source>Server details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_co_download-coverage">
+        <source>Download coverage</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-contrac.ts
+++ b/translations/harbour-contrac.ts
@@ -55,10 +55,6 @@
         <source>Received</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-settings_he_servers">
-        <source>Servers</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-settings_tf_download_server">
         <source>Download server</source>
         <translation type="unfinished"></translation>
@@ -307,6 +303,14 @@
     <message id="contrac-info_view-again">
         <source>You can view this page again by visiting the About page.</source>
         <oldsource>You can view this page again by visiting the About page</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_he_server_details">
+        <source>Server details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_co_download-coverage">
+        <source>Download coverage</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
The servers provide diagnosis key downloads in blocks of either hours or
days. Previously, the hourly files were downloaded, but on some recent
dates the hourly files have been missing, while the day files have still
been available.

This changes the download code to collect the day files rather than the
hour files.

In addition it also allows the region prefix to be changed, currently
between Germnay (DE) and Europe (EUR).