### PR TITLE
Return -1 if dbus still is a nullptr after initialising and 0 if it's initialized correctly.

### DIFF
--- a/contracd/src/contracd.cpp
+++ b/contracd/src/contracd.cpp
@@ -48,8 +48,8 @@ int main(int argc, char *argv[])
         setlinebuf(stderr);
 
         bool dbusInterfaceResult;
-        dbus = new DBusInterface(nullptr, &dbusInterfaceResult);
-        result = (dbus == nullptr || !dbusInterfaceResult) ? -1 : 0;
+        dbus = new DBusInterface(&dbusInterfaceResult);
+        result = !dbusInterfaceResult ? -1 : 0;
     }
     else {
         qDebug() << "No /tmp directory";

--- a/contracd/src/contracd.cpp
+++ b/contracd/src/contracd.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
         setlinebuf(stderr);
 
         bool dbusInterfaceResult;
-        dbus = new DBusInterface(dbusInterfaceResult);
+        dbus = new DBusInterface(nullptr, &dbusInterfaceResult);
         result = (dbus == nullptr || !dbusInterfaceResult) ? -1 : 0;
     }
     else {

--- a/contracd/src/contracd.cpp
+++ b/contracd/src/contracd.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
         setlinebuf(stderr);
 
         dbus = new DBusInterface();
-        result = dbus == nullptr ? 0 : 1;
+        result = dbus == nullptr ? -1 : 0;
     }
     else {
         qDebug() << "No /tmp directory";

--- a/contracd/src/contracd.cpp
+++ b/contracd/src/contracd.cpp
@@ -47,8 +47,9 @@ int main(int argc, char *argv[])
         setlinebuf(stdout);
         setlinebuf(stderr);
 
-        dbus = new DBusInterface();
-        result = dbus == nullptr ? -1 : 0;
+        bool dbusInterfaceResult;
+        dbus = new DBusInterface(dbusInterfaceResult);
+        result = (dbus == nullptr || !dbusInterfaceResult) ? -1 : 0;
     }
     else {
         qDebug() << "No /tmp directory";

--- a/contracd/src/dbusinterface.cpp
+++ b/contracd/src/dbusinterface.cpp
@@ -4,13 +4,15 @@
 
 #include "dbusinterface.h"
 
-DBusInterface::DBusInterface(bool &result, QObject *parent)
+DBusInterface::DBusInterface(QObject *parent, bool *success)
     : QObject(parent)
     , m_connection(QDBusConnection::sessionBus())
 {
     qDebug() << "CONTRAC: Initialising the dbus interface";
 
     Settings &settings = Settings::getInstance();
+
+    bool result;
 
     qDBusRegisterMetaType<TemporaryExposureKey>();
     qDBusRegisterMetaType<ExposureInformation>();
@@ -47,6 +49,11 @@ DBusInterface::DBusInterface(bool &result, QObject *parent)
     if (settings.enabled()) {
         qDebug() << "Starting automatically";
         m_exposureNotification.start();
+    }
+
+    //Make result optionally accessible outside
+    if (success) {
+        *success = result;
     }
 }
 

--- a/contracd/src/dbusinterface.cpp
+++ b/contracd/src/dbusinterface.cpp
@@ -4,12 +4,10 @@
 
 #include "dbusinterface.h"
 
-DBusInterface::DBusInterface(QObject *parent)
+DBusInterface::DBusInterface(bool &result, QObject *parent)
     : QObject(parent)
     , m_connection(QDBusConnection::sessionBus())
 {
-    bool result;
-
     qDebug() << "CONTRAC: Initialising the dbus interface";
 
     Settings &settings = Settings::getInstance();

--- a/contracd/src/dbusinterface.cpp
+++ b/contracd/src/dbusinterface.cpp
@@ -4,7 +4,7 @@
 
 #include "dbusinterface.h"
 
-DBusInterface::DBusInterface(QObject *parent, bool *success)
+DBusInterface::DBusInterface(bool *success, QObject *parent)
     : QObject(parent)
     , m_connection(QDBusConnection::sessionBus())
 {

--- a/contracd/src/dbusinterface.h
+++ b/contracd/src/dbusinterface.h
@@ -26,7 +26,7 @@ class DBusInterface : public QObject
     Q_PROPERTY(qint32 rssiCorrection READ rssiCorrection WRITE setRssiCorrection NOTIFY rssiCorrectionChanged)
 
 public:
-    explicit DBusInterface(QObject *parent = nullptr);
+    explicit DBusInterface(bool &result, QObject *parent = nullptr);
     ~DBusInterface();
 
     Q_INVOKABLE qint32 status() const;

--- a/contracd/src/dbusinterface.h
+++ b/contracd/src/dbusinterface.h
@@ -26,7 +26,7 @@ class DBusInterface : public QObject
     Q_PROPERTY(qint32 rssiCorrection READ rssiCorrection WRITE setRssiCorrection NOTIFY rssiCorrectionChanged)
 
 public:
-    explicit DBusInterface(bool &result, QObject *parent = nullptr);
+    explicit DBusInterface(QObject *parent = nullptr, bool *success = nullptr);
     ~DBusInterface();
 
     Q_INVOKABLE qint32 status() const;

--- a/contracd/src/dbusinterface.h
+++ b/contracd/src/dbusinterface.h
@@ -26,7 +26,7 @@ class DBusInterface : public QObject
     Q_PROPERTY(qint32 rssiCorrection READ rssiCorrection WRITE setRssiCorrection NOTIFY rssiCorrectionChanged)
 
 public:
-    explicit DBusInterface(QObject *parent = nullptr, bool *success = nullptr);
+    explicit DBusInterface(bool *success = nullptr, QObject *parent = nullptr);
     ~DBusInterface();
 
     Q_INVOKABLE qint32 status() const;


### PR DESCRIPTION
Waiting for a decision on how to handle a failed registration in the constructor of `DBusInterface`:
Options:
1. Either throw an exception and catch it in main(), changing the result boolean there.
2. Add a member to `DBusInterface` which stores the constructor result.