### PR TITLE
Add build.yml for github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: SailfishOS build
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  clang-format-checking:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: RafikFarhad/clang-format-github-action@v1
+        with:
+          sources: "src/**/*.h,src/**/*.c,test/**/*.c"
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Prepare
+      run: mkdir output
+
+    - name: Build armv7hl
+      id: build_armv7hl
+      uses: coderus/github-sfos-build@master
+      with:
+        release: 4.0.1.48
+
+    - name: Build i486
+      id: build_i486
+      uses: coderus/github-sfos-build@master
+      with:
+        release: 4.0.1.48
+        arch: i486
+
+    - name: Upload build result
+      uses: actions/upload-artifact@v2
+      with:
+        name: rpms
+        path: RPMS
+
+    - name: Create release
+      if: contains(github.ref, 'release')
+      run: |
+        set -x
+        assets=()
+        for asset in RPMS/*.rpm; do
+          assets+=("-a" "$asset")
+        done
+        tag_name="${GITHUB_REF##*/}"
+        hub release create "${assets[@]}" -m "$tag_name" "$tag_name"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/src/harbour-contrac.cpp
+++ b/src/harbour-contrac.cpp
@@ -9,6 +9,7 @@
 #include <openssl/rand.h>
 #include <QtQuick>
 
+#include "../contracd/src/version.h"
 #include "appsettings.h"
 #include "autoupdate.h"
 #include "dbusproxy.h"
@@ -17,7 +18,6 @@
 #include "imageprovider.h"
 #include "riskstatus.h"
 #include "upload.h"
-#include "../contracd/src/version.h"
 
 #include <sailfishapp.h>
 


### PR DESCRIPTION
Build part stolen from https://github.com/CODeRUS/screencast/raw/master/.github/workflows/build.yml

Use clang-format version 10, but that should be ok for our project. (I used v11 initially but v10 doesn't format anything diffrent for our project).

On line in our project is still misformatted. Hopefully this will prevent this and other issues in the future while enabling easy deployment of rpm files on Github without using Mer OBS.

@llewelld You need to provide a GH token as secret (Last line of build.yml) https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow