### PR TITLE
Set OpenSSL 1.1.1 as the default build option

### DIFF
--- a/config.pri
+++ b/config.pri
@@ -1,2 +1,2 @@
 # Enable to force use of OpenSSL 1.1.1 or greater
-#DEFINES += OPENSSL_GE_1_1_1
+DEFINES += OPENSSL_GE_1_1_1


### PR DESCRIPTION
With the full release of Sailfish OS 4.4.1 it makes sense to have
OpenSSL 1.1.1 as the default build option now.