### PR TITLE
Add notifications for important events

### DIFF
--- a/contrac.pro
+++ b/contrac.pro
@@ -40,6 +40,7 @@ HEADERS += \
     proto/submissionpayload.pb.h \
     proto/applicationConfiguration.pb.h \
     src/appsettings.h \
+    src/appstatus.h \
     src/autoupdate.h \
     src/dbusproxy.h \
     src/contactmodel.h \
@@ -52,6 +53,7 @@ HEADERS += \
     contracd/src/exposureconfiguration.h \
     contracd/src/zipistreambuffer.h \
     contracd/src/version.h \
+    src/notifications.h \
     src/riskscoreclass.h \
     src/riskstatus.h \
     src/serveraccess.h \
@@ -63,6 +65,7 @@ SOURCES += \
     proto/submissionpayload.pb.cc \
     proto/applicationConfiguration.pb.cc \
     src/appsettings.cpp \
+    src/appstatus.cpp \
     src/autoupdate.cpp \
     src/downloadconfig.cpp \
     src/harbour-contrac.cpp \
@@ -75,6 +78,7 @@ SOURCES += \
     contracd/src/temporaryexposurekey.cpp \
     contracd/src/exposureconfiguration.cpp \
     contracd/src/zipistreambuffer.cpp \
+    src/notifications.cpp \
     src/riskscoreclass.cpp \
     src/riskstatus.cpp \
     src/serveraccess.cpp \
@@ -122,6 +126,7 @@ PKGCONFIG += \
     libxml-2.0 \
     libcurl \
     keepalive \
+    nemonotifications-qt5 \
     protobuf-lite \
     quazip \
     sailfishsecrets

--- a/qml/harbour-contrac.qml
+++ b/qml/harbour-contrac.qml
@@ -50,6 +50,23 @@ ApplicationWindow
         }
     }
 
+    AppStatus {
+        id: appStatus
+
+        statusOfDownload: download.status
+        statusOfUpload: upload.status
+        updating: root.updating
+        bluetoothBusy: dbusproxy.isBusy
+        bluetoothEnabled: dbusproxy.isEnabled
+        atRisk: riskStatus.riskClassIndex > 0
+        downloadAvailable: root.downloadAvailable
+
+        onNotifyAtRisk: Notifications.notifyAtRisk(riskStatus.riskClassLabel)
+        onNotifyUpdateSuccessful: Notifications.notifyUpdateSuccessful()
+        onNotifyDownloadError: Notifications.notifyDownloadError()
+        onNotifyUploadError: Notifications.notifyUploadError()
+    }
+
     function updateSummary() {
         console.log("Exposure summary")
         var summary = dbusproxy.getExposureSummary(token)

--- a/qml/pages/Main.qml
+++ b/qml/pages/Main.qml
@@ -145,36 +145,40 @@ Page {
                     }
 
                     text: {
-                        if (updating) {
+                        switch (appStatus.status) {
+                        case AppStatus.Updating:
                             //% "Updating"
                             return qsTrId("contrac-main_la_status-updating")
-                        } else if (upload.uploading) {
+                        case AppStatus.Uploading:
                             //% "Uploading"
                             return qsTrId("contrac-main_la_status-uploading")
-                        } else if (download.downloading) {
+                        case AppStatus.Downloading:
                             //% "Downloading"
                             return qsTrId("contrac-main_la_status-downloading")
-                        } else if (upload.status === Upload.StatusError) {
+                        case AppStatus.ErrorUploading:
                             //% "Error uploading"
                             return qsTrId("contrac-main_la_status-upload_error")
-                        } else if (download.status === Download.StatusError) {
+                        case AppStatus.ErrorDownloading:
                             //% "Error downloading"
                             return qsTrId("contrac-main_la_status-download_error")
-                        } else if (dbusproxy.isBusy) {
+                        case AppStatus.BluetoothBusy:
                             //% "Busy"
                             return qsTrId("contrac-main_la_status-busy")
-                        } else if (riskStatus.riskClassIndex > 0) {
+                        case AppStatus.AtRisk:
                             //% "At risk"
                             return qsTrId("contrac-main_la_status-daily-update-required")
-                        } else if (downloadAvailable) {
+                        case AppStatus.DailyUpdateRequired:
                             //% "Daily update required"
                             return qsTrId("contrac-main_la_status-at-risk")
-                        } else if (dbusproxy.isEnabled) {
+                        case AppStatus.Active:
                             //% "Active"
                             return qsTrId("contrac-main_la_status-active")
-                        } else {
+                        case AppStatus.Disabled:
                             //% "Disabled"
                             return qsTrId("contrac-main_la_status-disabled")
+                        default:
+                            //% "Unknown"
+                            return qsTrId("contrac-main_la_status-unknown")
                         }
                     }
                     color: Theme.highlightColor

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -31,8 +31,9 @@ Page {
             }
 
             SectionHeader {
-                //% "Daily update"
-                text: qsTrId("contrac-settings_he_daily-update")
+                //: General settings header
+                //% "General"
+                text: qsTrId("contrac-settings_he_general")
             }
 
             TextSwitch {
@@ -65,6 +66,36 @@ Page {
                             AppSettings.autoUpdateTime = ((page.hour * 60) + page.minute) * 60
                         })
                     })
+                }
+            }
+
+            ComboBox {
+                //: For choosing the level of notification to display
+                //% "Notifications"
+                label: qsTrId("contrac-settings_cb_notifications")
+                currentIndex: AppSettings.notifyLevel
+
+                menu: ContextMenu {
+                    MenuItem {
+                        //% "None"
+                        text: qsTrId("contrac-settings_cb_notifications-none")
+                        onClicked: AppSettings.notifyLevel = Notifications.None
+                    }
+                    MenuItem {
+                        //% "Risk warnings only"
+                        text: qsTrId("contrac-settings_cb_notifications-warnings")
+                        onClicked: AppSettings.notifyLevel = Notifications.Warnings
+                    }
+                    MenuItem {
+                        //% "Warnings and info"
+                        text: qsTrId("contrac-settings_cb_notifications-info")
+                        onClicked: AppSettings.notifyLevel = Notifications.Info
+                    }
+                    MenuItem {
+                        //% "All"
+                        text: qsTrId("contrac-settings_cb_notifications-all")
+                        onClicked: AppSettings.notifyLevel = Notifications.All
+                    }
                 }
             }
 

--- a/rpm/harbour-contrac.spec
+++ b/rpm/harbour-contrac.spec
@@ -26,6 +26,7 @@ BuildRequires:  pkgconfig(libcurl)
 BuildRequires:  pkgconfig(libxml-2.0)
 BuildRequires:  pkgconfig(quazip)
 BuildRequires:  pkgconfig(keepalive)
+BuildRequires:  pkgconfig(nemonotifications-qt5)
 BuildRequires:  protobuf-compiler
 BuildRequires:  desktop-file-utils
 

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -6,6 +6,7 @@
 #include <QSettings>
 
 #include "../contracd/src/exposuresummary.h"
+#include "notifications.h"
 #include "riskscoreclass.h"
 
 class QQmlEngine;
@@ -25,6 +26,8 @@ class AppSettings : public QObject
     Q_PROPERTY(QString countryCode READ countryCode WRITE setCountryCode NOTIFY countryCodeChanged)
     Q_PROPERTY(bool autoUpdate READ autoUpdate WRITE setAutoUpdate NOTIFY autoUpdateChanged)
     Q_PROPERTY(qint32 autoUpdateTime READ autoUpdateTime WRITE setAutoUpdateTime NOTIFY autoUpdateTimeChanged)
+    Q_PROPERTY(Notifications::NotifyLevel notifyLevel READ notifyLevel WRITE setNotifyLevel NOTIFY notifyLevelChanged)
+    Q_PROPERTY(QList<quint32> notifyIds READ notifyIds WRITE setNotifyIds NOTIFY notifyIdsChanged)
 
     // Attenuation duration properties
     Q_PROPERTY(QList<double> riskWeights READ riskWeights WRITE setRiskWeights NOTIFY riskWeightsChanged)
@@ -57,6 +60,8 @@ public:
     bool autoUpdate() const;
     qint32 autoUpdateTime() const;
     QDate regTokenReceived() const;
+    Notifications::NotifyLevel notifyLevel() const;
+    QList<quint32> notifyIds() const;
 
     // Get attenuation duration properties
     QList<double> riskWeights() const;
@@ -75,6 +80,8 @@ public:
     void setAutoUpdate(bool autoUpdate);
     void setAutoUpdateTime(qint32 autoUpdateTime);
     void setRegTokenReceived(const QDate &receivedDate);
+    void setNotifyLevel(Notifications::NotifyLevel notifyLevel);
+    void setNotifyIds(QList<quint32> notifyIds);
 
     // Set attenuation duration properties
     void setRiskWeights(QList<double> riskWeights);
@@ -83,6 +90,7 @@ public:
     void setRiskScoreClasses(QList<RiskScoreClass> riskScoreClasses);
 
 signals:
+    // General property signals
     void downloadServerChanged();
     void uploadServerChanged();
     void verificationServerChanged();
@@ -90,12 +98,16 @@ signals:
     void summaryUpdatedChanged();
     void infoViewedChanged();
     void countryCodeChanged();
+    void autoUpdateChanged();
+    void autoUpdateTimeChanged();
+    void notifyLevelChanged();
+    void notifyIdsChanged();
+
+    // Attenuation duration property signals
     void riskWeightsChanged();
     void defaultBuckeOffsetChanged();
     void normalizationDivisorChanged();
     void riskScoreClassesChanged();
-    void autoUpdateChanged();
-    void autoUpdateTimeChanged();
     void regTokenReceivedChanged();
 
 private:
@@ -106,6 +118,7 @@ private:
     static AppSettings *instance;
     QSettings m_settings;
 
+    // General properties
     QString m_imageDir;
     QString m_downloadServer;
     QString m_uploadServer;
@@ -114,13 +127,20 @@ private:
     QDateTime m_summaryUpdated;
     quint32 m_infoViewed;
     QString m_countryCode;
+    bool m_autoUpdate;
+    qint32 m_autoUpdateTime;
+    Notifications::NotifyLevel m_notifyLevel;
+    QList<quint32> m_notifyIds;
+
+    // Attenuation duration properties
     QList<double> m_riskWeights;
     qint32 m_defaultBuckeOffset;
     qint32 m_normalizationDivisor;
     QList<RiskScoreClass> m_riskScoreClasses;
-    bool m_autoUpdate;
-    qint32 m_autoUpdateTime;
     QDate m_regTokenReceived;
 };
+
+QDataStream &operator<<(QDataStream &out, const QList<quint32> &list);
+QDataStream &operator>>(QDataStream &in, QList<quint32> &list);
 
 #endif // APPSETTINGS_H

--- a/src/appstatus.cpp
+++ b/src/appstatus.cpp
@@ -1,0 +1,171 @@
+#include "appstatus.h"
+
+AppStatus::AppStatus(QObject *parent)
+    : QObject(parent)
+    , m_status(Disabled)
+    , m_statusOfDownload()
+    , m_statusOfUpload()
+    , m_updating()
+    , m_bluetoothBusy()
+    , m_bluetoothEnabled()
+    , m_atRisk()
+    , m_downloadAvailable()
+{
+}
+
+AppStatus::Status AppStatus::status() const
+{
+    return m_status;
+}
+
+void AppStatus::updateStatus()
+{
+    Status status = m_status;
+
+    if (m_updating) {
+        m_status = Updating;
+    }
+    else if ((m_statusOfUpload != Upload::StatusIdle) && (m_statusOfUpload != Upload::StatusError)) {
+        m_status = Uploading;
+    }
+    else if ((m_statusOfDownload != Download::StatusIdle) && (m_statusOfDownload != Download::StatusError)) {
+        m_status = Downloading;
+    }
+    else if (m_statusOfUpload == Upload::StatusError) {
+        m_status = ErrorUploading;
+    }
+    else if (m_statusOfDownload == Download::StatusError) {
+        m_status = ErrorDownloading;
+    }
+    else if (m_bluetoothBusy) {
+        m_status = BluetoothBusy;
+    }
+    else if (m_atRisk) {
+        m_status = AtRisk;
+    }
+    else if (m_downloadAvailable) {
+        m_status = DailyUpdateRequired;
+    }
+    else if (m_bluetoothEnabled) {
+        m_status = Active;
+    }
+    else {
+        m_status = Disabled;
+    }
+
+    if (m_status != status) {
+        emit statusChanged();
+    }
+}
+
+Download::Status AppStatus::statusOfDownload() const
+{
+    return m_statusOfDownload;
+}
+
+Upload::Status AppStatus::statusOfUpload() const
+{
+    return m_statusOfUpload;
+}
+
+bool AppStatus::updating() const
+{
+    return m_updating;
+}
+
+bool AppStatus::bluetoothBusy() const
+{
+    return m_bluetoothBusy;
+}
+
+bool AppStatus::bluetoothEnabled() const
+{
+    return m_bluetoothEnabled;
+}
+
+bool AppStatus::atRisk() const
+{
+    return m_atRisk;
+}
+
+bool AppStatus::downloadAvailable() const
+{
+    return m_downloadAvailable;
+}
+
+void AppStatus::setStatusOfDownload(Download::Status statusOfDownload)
+{
+    if (m_statusOfDownload != statusOfDownload) {
+        m_statusOfDownload = statusOfDownload;
+        emit statusOfDownloadChanged();
+        updateStatus();
+        if (statusOfDownload == Download::StatusError) {
+            emit notifyDownloadError();
+        }
+    }
+}
+
+void AppStatus::setStatusOfUpload(Upload::Status statusOfUpload)
+{
+    if (m_statusOfUpload != statusOfUpload) {
+        m_statusOfUpload = statusOfUpload;
+        emit statusOfUploadChanged();
+        updateStatus();
+        if (statusOfUpload == Upload::StatusError) {
+            emit notifyUploadError();
+        }
+    }
+}
+
+void AppStatus::setUpdating(bool updating)
+{
+    if (m_updating != updating) {
+        m_updating = updating;
+        emit updatingChanged();
+        updateStatus();
+        if (!updating) {
+            if (m_atRisk) {
+                emit notifyAtRisk();
+            }
+            else {
+                emit notifyUpdateSuccessful();
+            }
+        }
+    }
+}
+
+void AppStatus::setBluetoothBusy(bool bluetoothBusy)
+{
+    if (m_bluetoothBusy != bluetoothBusy) {
+        m_bluetoothBusy = bluetoothBusy;
+        emit bluetoothBusyChanged();
+        updateStatus();
+    }
+}
+
+void AppStatus::setBluetoothEnabled(bool bluetoothEnabled)
+{
+    if (m_bluetoothEnabled != bluetoothEnabled) {
+        m_bluetoothEnabled = bluetoothEnabled;
+        emit bluetoothEnabledChanged();
+        updateStatus();
+    }
+}
+
+void AppStatus::setAtRisk(bool atRisk)
+{
+    if (m_atRisk != atRisk) {
+        m_atRisk = atRisk;
+        emit atRiskChanged();
+        updateStatus();
+    }
+}
+
+void AppStatus::setDownloadAvailable(bool downloadAvailable)
+{
+    if (m_downloadAvailable != downloadAvailable) {
+        m_downloadAvailable = downloadAvailable;
+        emit downloadAvailableChanged();
+        updateStatus();
+    }
+}

--- a/src/appstatus.h
+++ b/src/appstatus.h
@@ -1,0 +1,88 @@
+#ifndef APPSTATUS_H
+#define APPSTATUS_H
+
+#include <QObject>
+
+#include "download.h"
+#include "upload.h"
+
+class AppStatus : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(Status status READ status NOTIFY statusChanged)
+
+    Q_PROPERTY(Download::Status statusOfDownload READ statusOfDownload WRITE setStatusOfDownload NOTIFY statusOfDownloadChanged)
+    Q_PROPERTY(Upload::Status statusOfUpload READ statusOfUpload WRITE setStatusOfUpload NOTIFY statusOfUploadChanged)
+    Q_PROPERTY(bool updating READ updating WRITE setUpdating NOTIFY updatingChanged)
+    Q_PROPERTY(bool bluetoothBusy READ bluetoothBusy WRITE setBluetoothBusy NOTIFY bluetoothBusyChanged)
+    Q_PROPERTY(bool bluetoothEnabled READ bluetoothEnabled WRITE setBluetoothEnabled NOTIFY bluetoothEnabledChanged)
+    Q_PROPERTY(bool atRisk READ atRisk WRITE setAtRisk NOTIFY atRiskChanged)
+    Q_PROPERTY(bool downloadAvailable READ downloadAvailable WRITE setDownloadAvailable NOTIFY downloadAvailableChanged)
+
+public:
+    explicit AppStatus(QObject *parent = nullptr);
+
+    enum Status
+    {
+        Updating,
+        Uploading,
+        Downloading,
+        ErrorUploading,
+        ErrorDownloading,
+        BluetoothBusy,
+        AtRisk,
+        DailyUpdateRequired,
+        Active,
+        Disabled
+    };
+    Q_ENUM(Status)
+
+    Status status() const;
+
+    Download::Status statusOfDownload() const;
+    Upload::Status statusOfUpload() const;
+    bool updating() const;
+    bool bluetoothBusy() const;
+    bool bluetoothEnabled() const;
+    bool atRisk() const;
+    bool downloadAvailable() const;
+
+    void setStatusOfDownload(Download::Status statusOfDownload);
+    void setStatusOfUpload(Upload::Status statusOfUpload);
+    void setUpdating(bool updating);
+    void setBluetoothBusy(bool bluetoothBusy);
+    void setBluetoothEnabled(bool bluetoothEnabled);
+    void setAtRisk(bool atRisk);
+    void setDownloadAvailable(bool downloadAvailable);
+
+signals:
+    void statusChanged();
+    void statusOfDownloadChanged();
+    void statusOfUploadChanged();
+    void updatingChanged();
+    void bluetoothBusyChanged();
+    void bluetoothEnabledChanged();
+    void atRiskChanged();
+    void downloadAvailableChanged();
+
+    // Notifications
+    void notifyUpdateSuccessful();
+    void notifyDownloadError();
+    void notifyUploadError();
+    void notifyAtRisk();
+
+private:
+    void updateStatus();
+
+private:
+    Status m_status;
+    Download::Status m_statusOfDownload;
+    Upload::Status m_statusOfUpload;
+    bool m_updating;
+    bool m_bluetoothBusy;
+    bool m_bluetoothEnabled;
+    bool m_atRisk;
+    bool m_downloadAvailable;
+};
+
+#endif // APPSTATUS_H

--- a/src/harbour-contrac.cpp
+++ b/src/harbour-contrac.cpp
@@ -11,11 +11,13 @@
 
 #include "../contracd/src/version.h"
 #include "appsettings.h"
+#include "appstatus.h"
 #include "autoupdate.h"
 #include "dbusproxy.h"
 #include "download.h"
 #include "downloadconfig.h"
 #include "imageprovider.h"
+#include "notifications.h"
 #include "riskstatus.h"
 #include "sfsecrethelper.h"
 #include "testresult.h"
@@ -47,9 +49,12 @@ int main(int argc, char *argv[])
     qRegisterMetaType<RiskScoreClass>();
     qRegisterMetaTypeStreamOperators<ExposureSummary>("ExposureSummary");
     qRegisterMetaTypeStreamOperators<RiskScoreClass>("RiskScoreClass");
+    qRegisterMetaType<QList<quint32>>();
+    qRegisterMetaTypeStreamOperators<QList<quint32>>("ListUInt");
 
     AppSettings::instantiate(app);
     SFSecretHelper::instantiate("contrac", app);
+    Notifications::instantiate(&AppSettings::getInstance());
 
     qmlRegisterType<DBusProxy>("uk.co.flypig.contrac", 1, 0, "DBusProxy");
     qmlRegisterType<TemporaryExposureKey>("uk.co.flypig.contrac", 1, 0, "TemporaryExposureKey");
@@ -62,9 +67,11 @@ int main(int argc, char *argv[])
     qmlRegisterType<RiskStatus>("uk.co.flypig.contrac", 1, 0, "RiskStatus");
     qmlRegisterType<AutoUpdate>("uk.co.flypig.contrac", 1, 0, "AutoUpdate");
     qmlRegisterType<TestResult>("uk.co.flypig.contrac", 1, 0, "TestResult");
+    qmlRegisterType<AppStatus>("uk.co.flypig.contrac", 1, 0, "AppStatus");
 
     qmlRegisterSingletonType<AppSettings>("uk.co.flypig.contrac", 1, 0, "AppSettings", AppSettings::provider);
     qmlRegisterSingletonType<SFSecretHelper>("uk.co.flypig.contrac", 1, 0, "SFSecretHelper", SFSecretHelper::provider);
+    qmlRegisterSingletonType<Notifications>("uk.co.flypig.contrac", 1, 0, "Notifications", Notifications::provider);
 
     QQuickView *view = SailfishApp::createView();
     // The engine takes ownership of the ImageProvider

--- a/src/notifications.cpp
+++ b/src/notifications.cpp
@@ -1,0 +1,168 @@
+#include <locale>
+#include <notification.h>
+#include <QCoreApplication>
+
+#include "appsettings.h"
+
+#include "notifications.h"
+
+// Notification types:
+// 1. Download error
+// 2. Upload error
+// 3. Update status
+
+Notifications *Notifications::instance = nullptr;
+
+Notifications::Notifications(QObject *parent)
+    : QObject(parent)
+    , m_settings(AppSettings::getInstance())
+    , m_uploadNotification(new Notification(this))
+    , m_downloadNotification(new Notification(this))
+    , m_statusNotification(new Notification(this))
+{
+    configureNotification(*m_uploadNotification);
+    configureNotification(*m_downloadNotification);
+    configureNotification(*m_statusNotification);
+
+    //: Upload error notification summary
+    //% "Error"
+    m_uploadNotification->setSummary(qtTrId("contrac-main_nt_notification-upload-error-summary"));
+    //: Upload error notification body
+    //% "Diagnosis key upload failed"
+    m_uploadNotification->setBody(qtTrId("contrac-main_nt_notification-upload-error-body"));
+    m_uploadNotification->setPreviewSummary(qtTrId("contrac-main_nt_notification-upload-error-summary"));
+    m_uploadNotification->setPreviewBody(qtTrId("contrac-main_nt_notification-upload-error-body"));
+
+    //: Download error notification summary
+    //% "Error"
+    m_downloadNotification->setSummary(qtTrId("contrac-main_nt_notification-download-error-summary"));
+    //: Download error notification body
+    //% "Diagnosis key download failed"
+    m_downloadNotification->setBody(qtTrId("contrac-main_nt_notification-download-error-body"));
+    m_downloadNotification->setPreviewSummary(qtTrId("contrac-main_nt_notification-download-error-summary"));
+    m_downloadNotification->setPreviewBody(qtTrId("contrac-main_nt_notification-download-error-body"));
+
+    //: Risk alert notification summary
+    //% "Risk level low"
+    m_statusNotification->setSummary(qtTrId("contrac-main_nt_notification-risk-warning-summary"));
+    //: Risk alert notification body
+    //% "Update completed successfully"
+    m_statusNotification->setBody(qtTrId("contrac-main_nt_notification-risk-warning-body"));
+    m_statusNotification->setPreviewSummary(qtTrId("contrac-main_nt_notification-risk-warning-summary"));
+    m_statusNotification->setPreviewBody(qtTrId("contrac-main_nt_notification-risk-warning-body"));
+
+    QList<quint32> notifyIds = m_settings.notifyIds();
+    if (notifyIds.size() == 3) {
+        m_uploadNotification->setReplacesId(notifyIds.first());
+        notifyIds.pop_front();
+        m_downloadNotification->setReplacesId(notifyIds.first());
+        notifyIds.pop_front();
+        m_statusNotification->setReplacesId(notifyIds.first());
+        notifyIds.pop_front();
+    }
+
+    connect(&m_settings, &AppSettings::notifyLevelChanged, this, &Notifications::notifyLevelChanged);
+}
+
+Notifications::~Notifications()
+{
+    QList<quint32> notifyIds;
+    notifyIds << m_uploadNotification->replacesId();
+    notifyIds << m_downloadNotification->replacesId();
+    notifyIds << m_statusNotification->replacesId();
+
+    m_settings.setNotifyIds(notifyIds);
+}
+
+void Notifications::instantiate(QObject *parent)
+{
+    if (instance == nullptr) {
+        instance = new Notifications(parent);
+    }
+}
+
+Notifications &Notifications::getInstance()
+{
+    return *instance;
+}
+
+QObject *Notifications::provider(QQmlEngine *engine, QJSEngine *scriptEngine)
+{
+    Q_UNUSED(engine)
+    Q_UNUSED(scriptEngine)
+
+    return instance;
+}
+
+void Notifications::configureNotification(Notification &notification)
+{
+    //% "Contrac"
+    notification.setAppName(qtTrId("contrac-main_nt_notification-app-name"));
+    notification.setAppIcon(QStringLiteral("harbour-contrac"));
+    notification.setHintValue(QStringLiteral("x-nemo-display-on"), true);
+    notification.setHintValue("x-nemo-priority", 100);
+    //% "Exposure Notification App"
+    notification.setSubText(qtTrId("contrac-main_nt_notification-sub-text"));
+}
+
+void Notifications::notifyDownloadError()
+{
+    if (m_settings.notifyLevel() >= NotifyLevel::Info) {
+        m_downloadNotification->publish();
+    }
+}
+
+void Notifications::notifyUploadError()
+{
+    if (m_settings.notifyLevel() >= NotifyLevel::Info) {
+        m_uploadNotification->publish();
+    }
+}
+
+void Notifications::notifyUpdateSuccessful()
+{
+    if (m_settings.notifyLevel() >= NotifyLevel::Info) {
+        //% "Exposure level updated"
+        m_statusNotification->setSummary(qtTrId("contrac-main_nt_notification-update-summary"));
+        //% "Update completed successfully"
+        m_statusNotification->setBody(qtTrId("contrac-main_nt_notification-update-body"));
+        m_statusNotification->setPreviewSummary(qtTrId("contrac-main_nt_notification-update-summary"));
+        m_statusNotification->setPreviewBody(qtTrId("contrac-main_nt_notification-update-body"));
+
+        m_statusNotification->publish();
+    }
+}
+
+void Notifications::notifyAtRisk(QString const &riskLabel)
+{
+    if (m_settings.notifyLevel() >= NotifyLevel::Warnings) {
+        //% "Risk level: %1"
+        m_statusNotification->setSummary(qtTrId("contrac-main_nt_notification-at-risk-body").arg(riskLabel));
+        //% "Consult your health service for appropriate action"
+        m_statusNotification->setBody(qtTrId("contrac-main_nt_notification-at-risk-summary"));
+        m_statusNotification->setPreviewSummary(qtTrId("contrac-main_nt_notification-at-risk-body").arg(riskLabel));
+        m_statusNotification->setPreviewBody(qtTrId("contrac-main_nt_notification-at-risk-summary"));
+
+        m_statusNotification->publish();
+    }
+}
+
+void Notifications::notifyLevelChanged()
+{
+    switch (m_settings.notifyLevel()) {
+    case None:
+        m_downloadNotification->close();
+        m_uploadNotification->close();
+        m_statusNotification->close();
+        break;
+    case Warnings:
+        m_downloadNotification->close();
+        m_uploadNotification->close();
+        break;
+    case Info:
+    case All:
+    default:
+        // Do nothing
+        break;
+    }
+}

--- a/src/notifications.h
+++ b/src/notifications.h
@@ -1,0 +1,55 @@
+#ifndef NOTIFICATIONS_H
+#define NOTIFICATIONS_H
+
+#include <QDebug>
+#include <QObject>
+
+class Notification;
+class AppSettings;
+
+class QQmlEngine;
+class QJSEngine;
+
+class Notifications : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit Notifications(QObject *parent = nullptr);
+    ~Notifications();
+
+    static void instantiate(QObject *parent = nullptr);
+    static Notifications &getInstance();
+    static QObject *provider(QQmlEngine *engine, QJSEngine *scriptEngine);
+
+    enum NotifyLevel
+    {
+        None,
+        Warnings,
+        Info,
+        All
+    };
+    Q_ENUM(NotifyLevel)
+
+public slots:
+    void notifyDownloadError();
+    void notifyUploadError();
+    void notifyUpdateSuccessful();
+    void notifyAtRisk(QString const &riskLabel);
+
+private:
+    void configureNotification(Notification &notification);
+
+private slots:
+    void notifyLevelChanged();
+
+private:
+    static Notifications *instance;
+
+    AppSettings &m_settings;
+    Notification *m_uploadNotification;
+    Notification *m_downloadNotification;
+    Notification *m_statusNotification;
+};
+
+#endif // NOTIFICATIONS_H

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -25,6 +25,7 @@ INCLUDEPATH += ../src/ ./mock/
 PKGCONFIG += \
     mlite5 \
     openssl \
+    nemonotifications-qt5 \
     protobuf-lite \
     quazip
 
@@ -39,6 +40,7 @@ HEADERS += \
     ../src/appsettings.h \
     ../src/riskstatus.h \
     ../src/riskscoreclass.h \
+    ../src/notifications.h \
     ../contracd/proto/contrac.pb.h \
     ../contracd/src/bleadvertisement.h \
     ../contracd/src/bleadvertisementmanager.h \
@@ -70,6 +72,7 @@ SOURCES += \
     ../src/appsettings.cpp \
     ../src/riskstatus.cpp \
     ../src/riskscoreclass.cpp \
+    ../src/notifications.cpp \
     ../contracd/proto/contrac.pb.cc \
     ../contracd/src/bleadvertisement.cpp \
     ../contracd/src/bleadvertisementmanager.cpp \

--- a/translations/harbour-contrac-de.ts
+++ b/translations/harbour-contrac-de.ts
@@ -437,5 +437,9 @@
         <source>Consult your health service for appropriate action</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="contrac-main_la_status-unknown">
+        <source>Unknown</source>
+        <translation type="unfinished">Unbekannt</translation>
+    </message>
 </context>
 </TS>

--- a/translations/harbour-contrac-de.ts
+++ b/translations/harbour-contrac-de.ts
@@ -312,10 +312,6 @@
         <source>Download coverage</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-settings_he_daily-update">
-        <source>Daily update</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-settings_ts_perform-daily-update">
         <source>Perform daily update</source>
         <translation type="unfinished">Tägliche Aktualisierung durchführen</translation>
@@ -359,6 +355,86 @@
     </message>
     <message id="contrac-main_bu_submit_keys">
         <source>Submit keys</source>
+        <translation type="unfinished">Unbekannt</translation>
+    </message>
+    <message id="contrac-settings_he_general">
+        <source>General</source>
+        <extracomment>General settings header</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications">
+        <source>Notifications</source>
+        <extracomment>For choosing the level of notification to display</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-none">
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-warnings">
+        <source>Risk warnings only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-info">
+        <source>Warnings and info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-all">
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-upload-error-summary">
+        <source>Error</source>
+        <extracomment>Upload error notification summary</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-upload-error-body">
+        <source>Diagnosis key upload failed</source>
+        <extracomment>Upload error notification body</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-download-error-summary">
+        <source>Error</source>
+        <extracomment>Download error notification summary</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-download-error-body">
+        <source>Diagnosis key download failed</source>
+        <extracomment>Download error notification body</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-risk-warning-summary">
+        <source>Risk level low</source>
+        <extracomment>Risk alert notification summary</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-risk-warning-body">
+        <source>Update completed successfully</source>
+        <extracomment>Risk alert notification body</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-app-name">
+        <source>Contrac</source>
+        <translation type="unfinished">Contrac</translation>
+    </message>
+    <message id="contrac-main_nt_notification-sub-text">
+        <source>Exposure Notification App</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-update-summary">
+        <source>Exposure level updated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-update-body">
+        <source>Update completed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-at-risk-body">
+        <source>Risk level: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-at-risk-summary">
+        <source>Consult your health service for appropriate action</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-contrac-en.ts
+++ b/translations/harbour-contrac-en.ts
@@ -439,5 +439,9 @@
         <source>Consult your health service for appropriate action</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="contrac-main_la_status-unknown">
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/harbour-contrac-en.ts
+++ b/translations/harbour-contrac-en.ts
@@ -314,10 +314,6 @@
         <source>Download coverage</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-settings_he_daily-update">
-        <source>Daily update</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-settings_ts_perform-daily-update">
         <source>Perform daily update</source>
         <translation type="unfinished"></translation>
@@ -361,6 +357,86 @@
     </message>
     <message id="contrac-main_bu_submit_keys">
         <source>Submit keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_he_general">
+        <source>General</source>
+        <extracomment>General settings header</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications">
+        <source>Notifications</source>
+        <extracomment>For choosing the level of notification to display</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-none">
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-warnings">
+        <source>Risk warnings only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-info">
+        <source>Warnings and info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-all">
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-upload-error-summary">
+        <source>Error</source>
+        <extracomment>Upload error notification summary</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-upload-error-body">
+        <source>Diagnosis key upload failed</source>
+        <extracomment>Upload error notification body</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-download-error-summary">
+        <source>Error</source>
+        <extracomment>Download error notification summary</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-download-error-body">
+        <source>Diagnosis key download failed</source>
+        <extracomment>Download error notification body</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-risk-warning-summary">
+        <source>Risk level low</source>
+        <extracomment>Risk alert notification summary</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-risk-warning-body">
+        <source>Update completed successfully</source>
+        <extracomment>Risk alert notification body</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-app-name">
+        <source>Contrac</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-sub-text">
+        <source>Exposure Notification App</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-update-summary">
+        <source>Exposure level updated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-update-body">
+        <source>Update completed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-at-risk-body">
+        <source>Risk level: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-at-risk-summary">
+        <source>Consult your health service for appropriate action</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-contrac-zh_CN.ts
+++ b/translations/harbour-contrac-zh_CN.ts
@@ -314,10 +314,6 @@
         <source>Download coverage</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-settings_he_daily-update">
-        <source>Daily update</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-settings_ts_perform-daily-update">
         <source>Perform daily update</source>
         <translation type="unfinished">执行每日更新</translation>
@@ -361,6 +357,86 @@
     </message>
     <message id="contrac-main_bu_submit_keys">
         <source>Submit keys</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message id="contrac-settings_he_general">
+        <source>General</source>
+        <extracomment>General settings header</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications">
+        <source>Notifications</source>
+        <extracomment>For choosing the level of notification to display</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-none">
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-warnings">
+        <source>Risk warnings only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-info">
+        <source>Warnings and info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-all">
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-upload-error-summary">
+        <source>Error</source>
+        <extracomment>Upload error notification summary</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-upload-error-body">
+        <source>Diagnosis key upload failed</source>
+        <extracomment>Upload error notification body</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-download-error-summary">
+        <source>Error</source>
+        <extracomment>Download error notification summary</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-download-error-body">
+        <source>Diagnosis key download failed</source>
+        <extracomment>Download error notification body</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-risk-warning-summary">
+        <source>Risk level low</source>
+        <extracomment>Risk alert notification summary</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-risk-warning-body">
+        <source>Update completed successfully</source>
+        <extracomment>Risk alert notification body</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-app-name">
+        <source>Contrac</source>
+        <translation type="unfinished">Contrac</translation>
+    </message>
+    <message id="contrac-main_nt_notification-sub-text">
+        <source>Exposure Notification App</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-update-summary">
+        <source>Exposure level updated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-update-body">
+        <source>Update completed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-at-risk-body">
+        <source>Risk level: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-at-risk-summary">
+        <source>Consult your health service for appropriate action</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-contrac-zh_CN.ts
+++ b/translations/harbour-contrac-zh_CN.ts
@@ -439,5 +439,9 @@
         <source>Consult your health service for appropriate action</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="contrac-main_la_status-unknown">
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
 </context>
 </TS>

--- a/translations/harbour-contrac.ts
+++ b/translations/harbour-contrac.ts
@@ -439,5 +439,9 @@
         <source>Consult your health service for appropriate action</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="contrac-main_la_status-unknown">
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/harbour-contrac.ts
+++ b/translations/harbour-contrac.ts
@@ -314,10 +314,6 @@
         <source>Download coverage</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="contrac-settings_he_daily-update">
-        <source>Daily update</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="contrac-settings_ts_perform-daily-update">
         <source>Perform daily update</source>
         <translation type="unfinished"></translation>
@@ -361,6 +357,86 @@
     </message>
     <message id="contrac-main_bu_submit_keys">
         <source>Submit keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_he_general">
+        <source>General</source>
+        <extracomment>General settings header</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications">
+        <source>Notifications</source>
+        <extracomment>For choosing the level of notification to display</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-none">
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-warnings">
+        <source>Risk warnings only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-info">
+        <source>Warnings and info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-settings_cb_notifications-all">
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-upload-error-summary">
+        <source>Error</source>
+        <extracomment>Upload error notification summary</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-upload-error-body">
+        <source>Diagnosis key upload failed</source>
+        <extracomment>Upload error notification body</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-download-error-summary">
+        <source>Error</source>
+        <extracomment>Download error notification summary</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-download-error-body">
+        <source>Diagnosis key download failed</source>
+        <extracomment>Download error notification body</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-risk-warning-summary">
+        <source>Risk level low</source>
+        <extracomment>Risk alert notification summary</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-risk-warning-body">
+        <source>Update completed successfully</source>
+        <extracomment>Risk alert notification body</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-app-name">
+        <source>Contrac</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-sub-text">
+        <source>Exposure Notification App</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-update-summary">
+        <source>Exposure level updated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-update-body">
+        <source>Update completed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-at-risk-body">
+        <source>Risk level: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="contrac-main_nt_notification-at-risk-summary">
+        <source>Consult your health service for appropriate action</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
The following events now trigger notifications displayed to the user:

1. Risk level greater than 0.
2. Errors downloading diagnosis keys.
3. Errors uploading diagnosis keys.
4. Successful processing of diagnosis keys.

The level of notification to show can also be configured from the Settings page.

Fixes #75.