### PR TITLE
Update build configuration for Sailfish OS 4.5

### DIFF
--- a/contrac.pro
+++ b/contrac.pro
@@ -128,10 +128,16 @@ PKGCONFIG += \
     keepalive \
     nemonotifications-qt5 \
     protobuf-lite \
-    quazip1-qt5 \
     sailfishsecrets
 
+greaterThan(SAILFISH_VERSION, 44) {
+    PKGCONFIG += quazip1-qt5
+} else {
+    PKGCONFIG += quazip
+}
+
 DEFINES += LINUX
+DEFINES += "SAILFISH_VERSION=$$SAILFISH_VERSION"
 
 QT += dbus
 

--- a/contrac.pro
+++ b/contrac.pro
@@ -128,7 +128,7 @@ PKGCONFIG += \
     keepalive \
     nemonotifications-qt5 \
     protobuf-lite \
-    quazip \
+    quazip1-qt5 \
     sailfishsecrets
 
 DEFINES += LINUX

--- a/contracd/contracd.pro
+++ b/contracd/contracd.pro
@@ -80,8 +80,13 @@ DISTFILES += \
 
 PKGCONFIG += \
     openssl \
-    protobuf-lite \
-    quazip1-qt5
+    protobuf-lite
+
+greaterThan(SAILFISH_VERSION, 44) {
+    PKGCONFIG += quazip1-qt5
+} else {
+    PKGCONFIG += quazip
+}
 
 QT += dbus
 

--- a/contracd/contracd.pro
+++ b/contracd/contracd.pro
@@ -81,7 +81,7 @@ DISTFILES += \
 PKGCONFIG += \
     openssl \
     protobuf-lite \
-    quazip
+    quazip1-qt5
 
 QT += dbus
 

--- a/contracd/src/zipistreambuffer.h
+++ b/contracd/src/zipistreambuffer.h
@@ -1,8 +1,8 @@
 #ifndef ZIPISTREAMBUFFER_H
 #define ZIPISTREAMBUFFER_H
 
-#include <quazip5/quazip.h>
-#include <quazip5/quazipfile.h>
+#include <quazip/quazip.h>
+#include <quazip/quazipfile.h>
 
 #include <iostream>
 

--- a/contracd/src/zipistreambuffer.h
+++ b/contracd/src/zipistreambuffer.h
@@ -1,8 +1,14 @@
 #ifndef ZIPISTREAMBUFFER_H
 #define ZIPISTREAMBUFFER_H
 
-#include <quazip/quazip.h>
-#include <quazip/quazipfile.h>
+#if SAILFISH_VERSION < 45
+    #include <quazip5/quazip.h>
+    #include <quazip5/quazipfile.h>
+#else
+    #include <quazip/quazip.h>
+    #include <quazip/quazipfile.h>
+#endif
+
 
 #include <iostream>
 

--- a/harbour-contrac.pro
+++ b/harbour-contrac.pro
@@ -12,3 +12,5 @@ DISTFILES += \
 OTHER_FILES += \
     README.md \
     .clang-format
+
+DEFINES += "SAILFISH_VERSION=$$SAILFISH_VERSION"

--- a/rpm/harbour-contrac.changes
+++ b/rpm/harbour-contrac.changes
@@ -11,6 +11,11 @@
 
 # * date Author's Name <author's email> version-release
 # - Summary of changes
+
+* Thu Feb 2 2023 David Llewellyn-Jones <david@flypig.co.uk> 0.7.10-1
+- Change quazip-devel naming for Sailfish OS 4.5 target.
+- Add make as a build requirement.
+
 * Sat May 14 2022 Oskar Roesler <oskar@oskar-roesler.de> 0.7.9-1
 - Require Qt Linguist pkg for tranlations. (#115) This package is preinstalled on the SDK, but not on OBS.
 - Add chum information to rpm spec file

--- a/rpm/harbour-contrac.changes
+++ b/rpm/harbour-contrac.changes
@@ -11,7 +11,7 @@
 
 # * date Author's Name <author's email> version-release
 # - Summary of changes
-* Sa May 14 2022 Oskar Roesler <oskar@oskar-roesler.de> 0.7.9-1
+* Sat May 14 2022 Oskar Roesler <oskar@oskar-roesler.de> 0.7.9-1
 - Require Qt Linguist pkg for tranlations. (#115) This package is preinstalled on the SDK, but not on OBS.
 - Add chum information to rpm spec file
 

--- a/rpm/harbour-contrac.spec
+++ b/rpm/harbour-contrac.spec
@@ -16,6 +16,7 @@ Requires:   openssl
 Requires:   protobuf-lite
 Requires:   sailfishsecretsdaemon-secretsplugins-default
 Requires:   qr-filter-qml-plugin
+BuildRequires:  make
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
@@ -25,7 +26,7 @@ BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(protobuf-lite)
 BuildRequires:  pkgconfig(libcurl)
 BuildRequires:  pkgconfig(libxml-2.0)
-BuildRequires:  pkgconfig(quazip)
+BuildRequires:  pkgconfig(quazip1-qt5)
 BuildRequires:  pkgconfig(keepalive)
 BuildRequires:  pkgconfig(nemonotifications-qt5)
 BuildRequires:  pkgconfig(sailfishsecrets)

--- a/rpm/harbour-contrac.spec
+++ b/rpm/harbour-contrac.spec
@@ -2,7 +2,8 @@ Name:       harbour-contrac
 
 %define version_major 0
 %define version_minor 7
-%define version_revis 9
+%define version_revis 10
+%define sailfish_version %( if [ -f /bin/awk ]; then awk -F= '$1=="VERSION_ID" { print $2 ;}' /etc/os-release | cut -d '.' -f1-2 | tr -d '.'; fi )
 
 Summary:    Contrac
 Version:    %{version_major}.%{version_minor}.%{version_revis}
@@ -26,7 +27,11 @@ BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(protobuf-lite)
 BuildRequires:  pkgconfig(libcurl)
 BuildRequires:  pkgconfig(libxml-2.0)
+%if %{sailfish_version} < 45
+BuildRequires:  pkgconfig(quazip)
+%else
 BuildRequires:  pkgconfig(quazip1-qt5)
+%endif
 BuildRequires:  pkgconfig(keepalive)
 BuildRequires:  pkgconfig(nemonotifications-qt5)
 BuildRequires:  pkgconfig(sailfishsecrets)
@@ -67,6 +72,7 @@ Unit tests for %{name}
   DEFINES+='VERSION_MINOR=%{version_minor}' \
   DEFINES+='VERSION_REVIS=%{version_revis}' \
   DEFINES+='VERSION=\"\\\"\"%{version_major}.%{version_minor}.%{version_revis}\"\\\"\"' \
+  SAILFISH_VERSION='%{sailfish_version}' \
   %{name}.pro
 make %{?_smp_mflags}
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -26,8 +26,15 @@ PKGCONFIG += \
     mlite5 \
     openssl \
     nemonotifications-qt5 \
-    protobuf-lite \
-    quazip1-qt5
+    protobuf-lite
+
+greaterThan(SAILFISH_VERSION, 44) {
+    PKGCONFIG += quazip1-qt5
+} else {
+    PKGCONFIG += quazip
+}
+
+DEFINES += "SAILFISH_VERSION=$$SAILFISH_VERSION"
 
 SOURCES += \
     test_tracing.cpp

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -27,7 +27,7 @@ PKGCONFIG += \
     openssl \
     nemonotifications-qt5 \
     protobuf-lite \
-    quazip
+    quazip1-qt5
 
 SOURCES += \
     test_tracing.cpp


### PR DESCRIPTION
Adds make and changes the quazip naming to match the requirements for the Sailfish OS 4.5 build target.

Bumps the version to 0.7.10-1.
