### PR TITLE
Obs version agnostic rpm build

### DIFF
--- a/contrac.pro
+++ b/contrac.pro
@@ -130,10 +130,10 @@ PKGCONFIG += \
     protobuf-lite \
     sailfishsecrets
 
-greaterThan(SAILFISH_VERSION, 44) {
-    PKGCONFIG += quazip1-qt5
-} else {
+lessThan(SAILFISH_VERSION, 40500) {
     PKGCONFIG += quazip
+} else {
+    PKGCONFIG += quazip1-qt5
 }
 
 DEFINES += LINUX

--- a/contracd/contracd.pro
+++ b/contracd/contracd.pro
@@ -82,10 +82,10 @@ PKGCONFIG += \
     openssl \
     protobuf-lite
 
-greaterThan(SAILFISH_VERSION, 44) {
-    PKGCONFIG += quazip1-qt5
-} else {
+lessThan(SAILFISH_VERSION, 40500) {
     PKGCONFIG += quazip
+} else {
+    PKGCONFIG += quazip1-qt5
 }
 
 QT += dbus

--- a/rpm/harbour-contrac.spec
+++ b/rpm/harbour-contrac.spec
@@ -3,7 +3,11 @@ Name:       harbour-contrac
 %define version_major 0
 %define version_minor 7
 %define version_revis 10
-%define sailfish_version %( if [ -f /bin/awk ]; then awk -F= '$1=="VERSION_ID" { print $2 ;}' /etc/os-release | cut -d '.' -f1-2 | tr -d '.'; fi )
+%if %{defined sailfishos_version}
+%define sailfish_version %{sailfishos_version}
+%else
+%define sailfish_version %( if [ -f /bin/awk ]; then awk -F= '$1=="VERSION_ID" { print $2 ;}' /etc/os-release | cut -d'.' -f1-3 | sed 's/\\./0/g'; fi )
+%endif
 
 Summary:    Contrac
 Version:    %{version_major}.%{version_minor}.%{version_revis}
@@ -27,7 +31,7 @@ BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(protobuf-lite)
 BuildRequires:  pkgconfig(libcurl)
 BuildRequires:  pkgconfig(libxml-2.0)
-%if %{sailfish_version} < 45
+%if 0%{?sailfish_version} < 40500
 BuildRequires:  pkgconfig(quazip)
 %else
 BuildRequires:  pkgconfig(quazip1-qt5)

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -28,13 +28,11 @@ PKGCONFIG += \
     nemonotifications-qt5 \
     protobuf-lite
 
-greaterThan(SAILFISH_VERSION, 44) {
-    PKGCONFIG += quazip1-qt5
-} else {
+lessThan(SAILFISH_VERSION, 40500) {
     PKGCONFIG += quazip
+} else {
+    PKGCONFIG += quazip1-qt5
 }
-
-DEFINES += "SAILFISH_VERSION=$$SAILFISH_VERSION"
 
 SOURCES += \
     test_tracing.cpp


### PR DESCRIPTION
Blocked due to `%{sailfishos_version} being bugged on OBS. The value of it is 40400, 40500 but should be 44, 45, etc.